### PR TITLE
feat(lang): IDE type-checking for `.uwk.ts` sugar via a Volar language plugin

### DIFF
--- a/.claude/skills/unworklet/SKILL.md
+++ b/.claude/skills/unworklet/SKILL.md
@@ -195,5 +195,5 @@ expectStable(r);
 position → `state.read()`. Scalar writes are still explicit `state.write(v)`.
 The body is wrapped in ambient `process(() => { ... })`. For IDE type-checking of
 the sugar (drop `// @ts-nocheck`), add `@unworklet/lang/typescript-plugin` to
-`tsconfig` `plugins` and `include` the shipped ambient `.d.ts`. See
-`@unworklet/lang`'s README → IDE support.
+`tsconfig` `plugins` and put the shipped ambient `.d.ts` in `files` (not `include` —
+`include` globs skip `node_modules`). See `@unworklet/lang`'s README → IDE support.

--- a/.claude/skills/unworklet/SKILL.md
+++ b/.claude/skills/unworklet/SKILL.md
@@ -194,5 +194,6 @@ expectStable(r);
 → `out.left.at(i).write(v)`, `buf[i]` → `buf.read(i)`, a bare `state` in a value
 position → `state.read()`. Scalar writes are still explicit `state.write(v)`.
 The body is wrapped in ambient `process(() => { ... })`. For IDE type-checking of
-the sugar (drop `// @ts-nocheck`), add the `@unworklet/lang/typescript-plugin` +
-`types: ["@unworklet/lang/ambient"]` to `tsconfig`. See `@unworklet/lang`'s README.
+the sugar (drop `// @ts-nocheck`), add `@unworklet/lang/typescript-plugin` to
+`tsconfig` `plugins` and `include` the shipped ambient `.d.ts`. See
+`@unworklet/lang`'s README → IDE support.

--- a/.claude/skills/unworklet/SKILL.md
+++ b/.claude/skills/unworklet/SKILL.md
@@ -186,12 +186,13 @@ expectStable(r);
 - No standalone `message<T>()`: main→worklet delivery is `event({ from: "main", name })`.
 - No `midiInput()/midiOutput()`: use `event.midi({ from | to: "main", name })`.
 - Import a processor with `?worklet`; don't import the raw module into the app.
-- Don't mix `.uwk.ts` sugar with the plain `.ts` API in one file; `.uwk.ts` needs a `// @ts-nocheck` header.
+- Don't mix `.uwk.ts` sugar with the plain `.ts` API in one file. A `.uwk.ts` needs a `// @ts-nocheck` header UNLESS the `@unworklet/lang` editor plugin is set up (then the sugar type-checks and the header is dropped).
 
 ## `.uwk.ts` sugar (optional)
 
 `.uwk.ts` desugars to the same primitives: `a * b` → `a.mul(b)`, `out.left[i] = v`
 → `out.left.at(i).write(v)`, `buf[i]` → `buf.read(i)`, a bare `state` in a value
 position → `state.read()`. Scalar writes are still explicit `state.write(v)`.
-The body is wrapped in ambient `process(() => { ... })`. See
-`@unworklet/lang`'s README.
+The body is wrapped in ambient `process(() => { ... })`. For IDE type-checking of
+the sugar (drop `// @ts-nocheck`), add the `@unworklet/lang/typescript-plugin` +
+`types: ["@unworklet/lang/ambient"]` to `tsconfig`. See `@unworklet/lang`'s README.

--- a/.gitignore
+++ b/.gitignore
@@ -44,5 +44,8 @@ playwright-report/
 # Transient lowered-`.uwk.ts` temp the vite-plugin build path writes then removes
 *.uwklowered.ts
 
+# Generated editor TS-server plugin bundle (built by @unworklet/lang's build.mjs)
+/packages/lang/typescript-plugin/
+
 # Vercel CLI project link (local, per-machine)
 .vercel

--- a/llms.txt
+++ b/llms.txt
@@ -62,7 +62,7 @@ includes it in `node.snapshot()`. A `publish`/`persistent` slot must be named.
 - There is **no** standalone `message<T>()`; main→worklet is `event({ from: "main", name })`.
 - MIDI is `event.midi({ from | to: "main", name })`, not a `midiInput()/midiOutput()` call.
 - Import processors with the `?worklet` query; don't import the raw module.
-- `.uwk.ts` sugar and the plain `.ts` API are not mixed in one file; `.uwk.ts` needs `// @ts-nocheck`.
+- `.uwk.ts` sugar and the plain `.ts` API are not mixed in one file. Without the `@unworklet/lang` editor plugin a `.uwk.ts` needs `// @ts-nocheck`; with it (`tsconfig` `plugins` + `types: ["@unworklet/lang/ambient"]`) the sugar type-checks and the header is dropped (see `@unworklet/lang`'s README → IDE support).
 
 ## Main-thread usage
 

--- a/llms.txt
+++ b/llms.txt
@@ -62,7 +62,7 @@ includes it in `node.snapshot()`. A `publish`/`persistent` slot must be named.
 - There is **no** standalone `message<T>()`; main→worklet is `event({ from: "main", name })`.
 - MIDI is `event.midi({ from | to: "main", name })`, not a `midiInput()/midiOutput()` call.
 - Import processors with the `?worklet` query; don't import the raw module.
-- `.uwk.ts` sugar and the plain `.ts` API are not mixed in one file. Without the `@unworklet/lang` editor plugin a `.uwk.ts` needs `// @ts-nocheck`; with it (`tsconfig` `plugins` + `types: ["@unworklet/lang/ambient"]`) the sugar type-checks and the header is dropped (see `@unworklet/lang`'s README → IDE support).
+- `.uwk.ts` sugar and the plain `.ts` API are not mixed in one file. Without the `@unworklet/lang` editor plugin a `.uwk.ts` needs `// @ts-nocheck`; install the plugin (`tsconfig` `plugins` + `include` the shipped ambient `.d.ts`) and the sugar type-checks so the header is dropped (see `@unworklet/lang`'s README → IDE support).
 
 ## Main-thread usage
 

--- a/llms.txt
+++ b/llms.txt
@@ -62,7 +62,7 @@ includes it in `node.snapshot()`. A `publish`/`persistent` slot must be named.
 - There is **no** standalone `message<T>()`; main→worklet is `event({ from: "main", name })`.
 - MIDI is `event.midi({ from | to: "main", name })`, not a `midiInput()/midiOutput()` call.
 - Import processors with the `?worklet` query; don't import the raw module.
-- `.uwk.ts` sugar and the plain `.ts` API are not mixed in one file. Without the `@unworklet/lang` editor plugin a `.uwk.ts` needs `// @ts-nocheck`; install the plugin (`tsconfig` `plugins` + `include` the shipped ambient `.d.ts`) and the sugar type-checks so the header is dropped (see `@unworklet/lang`'s README → IDE support).
+- `.uwk.ts` sugar and the plain `.ts` API are not mixed in one file. Without the `@unworklet/lang` editor plugin a `.uwk.ts` needs `// @ts-nocheck`; install the plugin (`tsconfig` `plugins` + the shipped ambient `.d.ts` in `files`, not `include` — `include` globs skip `node_modules`) and the sugar type-checks so the header is dropped (see `@unworklet/lang`'s README → IDE support).
 
 ## Main-thread usage
 

--- a/packages/lang/README.md
+++ b/packages/lang/README.md
@@ -23,13 +23,16 @@ Same declarations as core, but the `process` body uses operators. There is no
 `defineProcessor` wrapper and no `return { process }` — the file _is_ the
 processor body, and `process(() => { ... })` is ambient. The core DSL names
 (`audioInput`, `state`, `param`, `forSample`, …) are ambient too: **write no
-import** — the lowering injects the `@unworklet/core` import for you. A
-`// @ts-nocheck` header is expected: the sugar is intentionally a type error
-until the plugin lowers it. `.named()` / `.expose({...})` with no name derive it
-from the binding.
+import** — the lowering injects the `@unworklet/core` import for you.
+`.named()` / `.expose({...})` with no name derive it from the binding.
+
+Out of the box, stock TypeScript flags the sugar (`a * b` on two `Node`s is an
+"operator cannot be applied" error), so a `// @ts-nocheck` header is needed.
+**Install the editor plugin ([IDE support](#ide-support)) and the header goes
+away** — the sugar type-checks, with hover / completion / go-to-definition on
+the operands.
 
 ```ts
-// @ts-nocheck — sugar is a TS error until lowered; the plugin lowers it at build.
 const input = audioInput({ channels: 2, name: "main" });
 const out = audioOutput({ channels: 2, name: "main" });
 const gain = param.f32({ default: 1, min: 0, max: 4, automationRate: "a-rate" }).named();
@@ -63,6 +66,38 @@ lowers to `state.read()`, but you still **write** it explicitly with
 writes use the index-assignment form above. `number op number` (e.g.
 `SAMPLE_RATE * 0.5`) is left untouched — only expressions involving a
 `Node`/`State` are lowered.
+
+## IDE support
+
+`.uwk.ts` is syntactically TypeScript, so any editor highlights it and navigates
+it with zero setup. To make the **sugar type-check** — no red squiggles on
+`a * b`, no `// @ts-nocheck` — add the TypeScript-server plugin and the ambient
+`.d.ts` to your `tsconfig.json`:
+
+```jsonc
+{
+  "compilerOptions": {
+    "plugins": [{ "name": "@unworklet/lang/typescript-plugin" }],
+    "types": ["@unworklet/lang/ambient"],
+  },
+}
+```
+
+In VS Code, also run **“TypeScript: Select TypeScript Version → Use Workspace
+Version”** so the editor loads the plugin. You then get, on the sugar itself:
+diagnostics, hover (`Node<"f32">`), completion (`input.` → `left` / `right` /
+`ch`), rename, and go-to-definition — all projected onto your `.uwk.ts` source.
+
+How it works (Volar): the plugin generates a virtual TypeScript file where only
+the sugar is desugared to the chain primitives stock TS accepts (`a * b` →
+`mul(a, b)`, `out.left[i] = v` → `out.left.at(i).write(v)`, a bare `state` read →
+`state.read()`), type-checks _that_, and maps every result back to your source.
+It uses the same desugar dispatch as the build, so the editor never disagrees
+with `lower()`. The plugin is edit-time only; the actual build still runs
+`lower()`.
+
+For CI / headless type-checking, the same language plugin drives a Volar program
+proxy — see `createUwkLanguagePlugin` in `@unworklet/lang`.
 
 ## API
 

--- a/packages/lang/README.md
+++ b/packages/lang/README.md
@@ -72,7 +72,7 @@ writes use the index-assignment form above. `number op number` (e.g.
 `.uwk.ts` is syntactically TypeScript, so any editor highlights it and navigates
 it with zero setup. To make the **sugar type-check** — no red squiggles on
 `a * b`, no `// @ts-nocheck` — add the TypeScript-server plugin to your
-`tsconfig.json`, and `include` the shipped ambient `.d.ts` (it declares
+`tsconfig.json`, and pull in the shipped ambient `.d.ts` via `files` (it declares
 `audioInput` / `state` / `process` / `input` / `out` / `$prev` … as globals):
 
 ```jsonc
@@ -80,18 +80,20 @@ it with zero setup. To make the **sugar type-check** — no red squiggles on
   "compilerOptions": {
     "plugins": [{ "name": "@unworklet/lang/typescript-plugin" }],
   },
-  "include": ["src", "node_modules/@unworklet/lang/dist/ambient.d.ts"],
+  "include": ["src"],
+  "files": ["node_modules/@unworklet/lang/dist/ambient.d.ts"],
 }
 ```
 
-(The ambient is `include`d by path rather than via `compilerOptions.types`
-because the `types` array does not resolve an `exports` subpath in every
-resolver.)
+(The ambient goes in `files`, not `compilerOptions.types` or `include`: the
+`types` array does not resolve an `exports` subpath in every resolver, and
+`include` globs skip `node_modules`. `files` entries are always loaded.)
 
 In VS Code, also run **“TypeScript: Select TypeScript Version → Use Workspace
-Version”** so the editor loads the plugin. You then get, on the sugar itself:
-diagnostics, hover (`Node<"f32">`), completion (`input.` → `left` / `right` /
-`ch`), rename, and go-to-definition — all projected onto your `.uwk.ts` source.
+Version”** so the editor loads the plugin (TS-server plugins only load under the
+workspace TypeScript, not VS Code's bundled one). You then get, on the sugar
+itself: diagnostics, hover (`Node<"f32">`), completion (`input.` → `left` /
+`right` / `ch`), rename, and go-to-definition — projected onto your `.uwk.ts`.
 
 How it works (Volar): the plugin generates a virtual TypeScript file where only
 the sugar is desugared to the chain primitives stock TS accepts (`a * b` →

--- a/packages/lang/README.md
+++ b/packages/lang/README.md
@@ -71,17 +71,22 @@ writes use the index-assignment form above. `number op number` (e.g.
 
 `.uwk.ts` is syntactically TypeScript, so any editor highlights it and navigates
 it with zero setup. To make the **sugar type-check** — no red squiggles on
-`a * b`, no `// @ts-nocheck` — add the TypeScript-server plugin and the ambient
-`.d.ts` to your `tsconfig.json`:
+`a * b`, no `// @ts-nocheck` — add the TypeScript-server plugin to your
+`tsconfig.json`, and `include` the shipped ambient `.d.ts` (it declares
+`audioInput` / `state` / `process` / `input` / `out` / `$prev` … as globals):
 
 ```jsonc
 {
   "compilerOptions": {
     "plugins": [{ "name": "@unworklet/lang/typescript-plugin" }],
-    "types": ["@unworklet/lang/ambient"],
   },
+  "include": ["src", "node_modules/@unworklet/lang/dist/ambient.d.ts"],
 }
 ```
+
+(The ambient is `include`d by path rather than via `compilerOptions.types`
+because the `types` array does not resolve an `exports` subpath in every
+resolver.)
 
 In VS Code, also run **“TypeScript: Select TypeScript Version → Use Workspace
 Version”** so the editor loads the plugin. You then get, on the sugar itself:

--- a/packages/lang/package.json
+++ b/packages/lang/package.json
@@ -4,7 +4,8 @@
   "description": "Build-time `.uwk.ts` → virtual `.ts` authoring frontend that lowers to `@unworklet/core`.",
   "license": "MIT",
   "files": [
-    "dist"
+    "dist",
+    "typescript-plugin"
   ],
   "type": "module",
   "exports": {
@@ -18,8 +19,8 @@
       "import": "./dist/browser.mjs"
     },
     "./typescript-plugin": {
-      "require": "./dist/typescript-plugin.cjs",
-      "default": "./dist/typescript-plugin.cjs"
+      "require": "./typescript-plugin/index.js",
+      "default": "./typescript-plugin/index.js"
     },
     "./ambient": {
       "types": "./dist/ambient.d.ts"

--- a/packages/lang/package.json
+++ b/packages/lang/package.json
@@ -41,7 +41,6 @@
     "@unworklet/core": "workspace:*",
     "@volar/language-core": "catalog:",
     "@volar/typescript": "catalog:",
-    "muggle-string": "catalog:",
     "typescript": "catalog:"
   },
   "devDependencies": {

--- a/packages/lang/package.json
+++ b/packages/lang/package.json
@@ -17,6 +17,14 @@
       "types": "./src/browser.ts",
       "import": "./dist/browser.mjs"
     },
+    "./typescript-plugin": {
+      "require": "./dist/typescript-plugin.cjs",
+      "default": "./dist/typescript-plugin.cjs"
+    },
+    "./ambient": {
+      "types": "./dist/ambient.d.ts"
+    },
+    "./ambient.d.ts": "./dist/ambient.d.ts",
     "./package.json": "./package.json"
   },
   "publishConfig": {
@@ -31,6 +39,9 @@
   },
   "dependencies": {
     "@unworklet/core": "workspace:*",
+    "@volar/language-core": "catalog:",
+    "@volar/typescript": "catalog:",
+    "muggle-string": "catalog:",
     "typescript": "catalog:"
   },
   "devDependencies": {

--- a/packages/lang/scripts/build.mjs
+++ b/packages/lang/scripts/build.mjs
@@ -12,7 +12,7 @@
  *  4. The ambient `.d.ts` is emitted from the single in-source `AMBIENT_DTS`
  *     string → `dist/ambient.d.ts`, the file users add to their `tsconfig` types.
  */
-import { writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 
 import { build } from "esbuild";
 
@@ -24,20 +24,30 @@ execSync("vp pack", { stdio: "inherit" });
 console.log("[unworklet/lang] build:browser (vite lib → dist/browser.mjs)");
 execSync("vp build --config vite.browser.config.ts", { stdio: "inherit" });
 
-console.log("[unworklet/lang] bundle TS plugin (→ dist/typescript-plugin.cjs)");
+// tsserver resolves a tsconfig `plugins` entry with a LEGACY resolver that ignores
+// the package `exports` map and only probes `<name>.js` / `<name>/index.js` (never
+// `.cjs`). So the plugin must live at `<pkg>/typescript-plugin/index.js` with a
+// sibling `package.json` marking it CommonJS (this package is `type: module`), so
+// `@unworklet/lang/typescript-plugin` resolves for the editor. `typescript` stays
+// external to share the editor's instance; the default export is re-published as
+// `module.exports` so tsserver gets the factory directly.
+console.log("[unworklet/lang] bundle TS plugin (→ typescript-plugin/index.js)");
+mkdirSync("typescript-plugin", { recursive: true });
 await build({
   entryPoints: ["src/typescript-plugin.ts"],
-  outfile: "dist/typescript-plugin.cjs",
+  outfile: "typescript-plugin/index.js",
   bundle: true,
   platform: "node",
   format: "cjs",
   target: "node18",
-  // tsserver provides `typescript`; sharing its instance is required.
   external: ["typescript"],
-  // esbuild emits `exports.default = …`; tsserver wants the factory at module.exports.
   footer: { js: "module.exports = module.exports.default;" },
   logLevel: "info",
 });
+writeFileSync(
+  "typescript-plugin/package.json",
+  `${JSON.stringify({ type: "commonjs" }, null, 2)}\n`,
+);
 
 console.log("[unworklet/lang] emit ambient .d.ts (→ dist/ambient.d.ts)");
 const ambientBundle = await build({

--- a/packages/lang/scripts/build.mjs
+++ b/packages/lang/scripts/build.mjs
@@ -1,17 +1,53 @@
 #!/usr/bin/env node
 /**
- * Two-stage build for @unworklet/lang. `vp pack` cleans `dist/` before writing,
- * so it must run FIRST; the vite lib build (`emptyOutDir: false`) then ADDS
- * `dist/browser.mjs` without wiping the packed main entry.
+ * Build for @unworklet/lang. `vp pack` cleans `dist/` before writing, so it runs
+ * FIRST; everything else (`emptyOutDir: false`) then ADDS to `dist/`.
  *  1. `vp pack` bundles the main entry (`src/index.ts`) → `dist/index.mjs`.
  *  2. `vp build` (vite lib mode) bundles `src/browser.ts` → `dist/browser.mjs`,
- *     inlining the type snapshot + worklet runtime via the build plugins (tsdown
- *     can't run vite plugins, so this entry is built separately).
+ *     inlining the type snapshot + worklet runtime via the build plugins.
+ *  3. esbuild bundles the editor TS-plugin entry → `dist/typescript-plugin.cjs`
+ *     (CJS, because tsserver loads plugins with `require`; `typescript` stays
+ *     external so it shares the editor's instance). The default export is
+ *     re-published as `module.exports` so tsserver gets the factory directly.
+ *  4. The ambient `.d.ts` is emitted from the single in-source `AMBIENT_DTS`
+ *     string → `dist/ambient.d.ts`, the file users add to their `tsconfig` types.
  */
-import { execSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+
+import { build } from "esbuild";
+
+const { execSync } = await import("node:child_process");
 
 console.log("[unworklet/lang] pack (→ dist/index.mjs)");
 execSync("vp pack", { stdio: "inherit" });
 
 console.log("[unworklet/lang] build:browser (vite lib → dist/browser.mjs)");
 execSync("vp build --config vite.browser.config.ts", { stdio: "inherit" });
+
+console.log("[unworklet/lang] bundle TS plugin (→ dist/typescript-plugin.cjs)");
+await build({
+  entryPoints: ["src/typescript-plugin.ts"],
+  outfile: "dist/typescript-plugin.cjs",
+  bundle: true,
+  platform: "node",
+  format: "cjs",
+  target: "node18",
+  // tsserver provides `typescript`; sharing its instance is required.
+  external: ["typescript"],
+  // esbuild emits `exports.default = …`; tsserver wants the factory at module.exports.
+  footer: { js: "module.exports = module.exports.default;" },
+  logLevel: "info",
+});
+
+console.log("[unworklet/lang] emit ambient .d.ts (→ dist/ambient.d.ts)");
+const ambientBundle = await build({
+  entryPoints: ["src/ambient.ts"],
+  bundle: true,
+  format: "esm",
+  platform: "neutral",
+  write: false,
+});
+const ambientModule = await import(
+  `data:text/javascript,${encodeURIComponent(ambientBundle.outputFiles[0].text)}`
+);
+writeFileSync("dist/ambient.d.ts", `${ambientModule.AMBIENT_DTS.trim()}\n`);

--- a/packages/lang/src/__sugar__/auto-name.test.ts
+++ b/packages/lang/src/__sugar__/auto-name.test.ts
@@ -594,6 +594,57 @@ test("a const whose initializer is NOT a call (object literal) is untouched", as
   expect(lowered).not.toContain(`name: "cfg"`);
 });
 
+test("options object with a SPREAD element still gets a name injected", async () => {
+  // A `...base` element is a SpreadAssignment, not a PropertyAssignment, so the
+  // `name`-presence scan must skip it (not crash) and still inject the binding name
+  // because no explicit `name` is present.
+  const lowered = lower(
+    mono(
+      `const base = { from: "main" } as const;
+const taps = event({ ...base });`,
+      `taps.onReceive(() => {}); out.ch(0).at(i).write(input.ch(0).at(i));`,
+    ),
+  );
+  expect(lowered).toContain(`name: "taps"`);
+});
+
+test("an explicit name AMONG a spread is still honored (not double-named)", async () => {
+  // The spread is skipped by the scan, but the explicit `name` property is found, so
+  // auto-name leaves the declaration untouched.
+  const lowered = lower(
+    mono(
+      `const base = { from: "main" } as const;
+const taps = event({ ...base, name: "explicit" });`,
+      `taps.onReceive(() => {}); out.ch(0).at(i).write(input.ch(0).at(i));`,
+    ),
+  );
+  expect(lowered).toContain(`name: "explicit"`);
+  expect(lowered).not.toContain(`name: "taps"`);
+});
+
+test("a no-argument name-required helper gets a fresh { name } options object", async () => {
+  // `audioInput()` has no first argument, so auto-name must CREATE the options
+  // object `{ name: "<binding>" }` rather than mutate an existing one.
+  const lowered = lower(
+    `const sideIn = audioInput();
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => { forSample((i) => { out.ch(0).at(i).write(0); }); });`,
+  );
+  expect(lowered).toContain(`audioInput({ name: "sideIn" })`);
+});
+
+test("a multi-declaration `const a = …, b = …` statement is left untouched", async () => {
+  // The auto-name pass only fires on a single-declaration statement; a comma list is
+  // passed through verbatim (no name derived for either binding).
+  const lowered = lower(
+    mono(
+      `const a = state.f32(0).named('a'), b = state.f32(1).named('b');`,
+      `out.ch(0).at(i).write(a.read().add(b.read()));`,
+    ),
+  );
+  expect(lowered).toContain(`const a = state.f32(0).named('a'), b = state.f32(1).named('b');`);
+});
+
 // ───────────────────────────────────────────────────────────────────────────
 // 7. Mixed: many declarations in one module, each named independently
 // ───────────────────────────────────────────────────────────────────────────

--- a/packages/lang/src/__sugar__/if-sugar.test.ts
+++ b/packages/lang/src/__sugar__/if-sugar.test.ts
@@ -642,3 +642,99 @@ test("accept: a JS-boolean if stays a build-time branch (the guard only fires on
   );
   expect(() => lower(src)).not.toThrow();
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// more unsupported DSP-cond shapes — each must throw `uwk-unsupported-if`, never
+// silently lower to one branch. These pin the rejection of every then/else shape
+// the three sugar forms (single write / symmetric write / guarded emit) reject.
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Lower `src` and return the thrown LowerError id (or "<no throw>"). */
+function lowerErrorId(src: string): string {
+  try {
+    lower(src);
+  } catch (e) {
+    return (e as LowerError).id;
+  }
+  return "<no throw>";
+}
+
+test("reject: then-branch is a single NON-write statement (a bare read)", () => {
+  // `s.read()` is not a write, so no single-write shape matches → refuse, don't drop.
+  const src = mono("const s = state.f32(0).named('s');", `if (input.ch(0).at(i) > 0) s.read();`);
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: then-branch is a declaration (not an expression statement)", () => {
+  const src = mono(
+    "const s = state.f32(0).named('s');",
+    `if (input.ch(0).at(i) > 0) { let z = i; }`,
+  );
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: an empty then-block matches neither emit nor write", () => {
+  const src = mono("const s = state.f32(0).named('s');", `if (input.ch(0).at(i) > 0) {}`);
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: writing to an output-channel sample inside a DSP-cond if", () => {
+  // `out.ch(0).at(i).write(v)` is a `.write` call, but the target is not a state /
+  // two-arg buffer write, so the single-write shape does not match.
+  const src = mono("", `if (input.ch(0).at(i) > 0) out.ch(0).at(i).write(f32(1));`);
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: symmetric if-else writing DIFFERENT kinds (state vs buffer)", () => {
+  const src = mono(
+    "const s = state.f32(0).named('s');\nconst buf = state.buffer.f32({ size: 8 }).named('buf');",
+    `if (input.ch(0).at(i) > 0) s.write(f32(1)); else buf[i] = f32(2);`,
+  );
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: symmetric if-else writing two DIFFERENT buffers", () => {
+  const src = mono(
+    "const a = state.buffer.f32({ size: 8 }).named('a');\nconst b = state.buffer.f32({ size: 8 }).named('b');",
+    `if (input.ch(0).at(i) > 0) a[i] = f32(1); else b[i] = f32(2);`,
+  );
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: symmetric if-else where the then-branch has two statements", () => {
+  const src = mono(
+    "const s = state.f32(0).named('s');\nconst t = state.f32(0).named('t');",
+    `if (input.ch(0).at(i) > 0) { s.write(f32(1)); t.write(f32(2)); } else s.write(f32(3));`,
+  );
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: a then-block mixing a declaration with an emit is not a guarded emit", () => {
+  const src = `const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const ev = event<{ x: number }>({ to: "main", name: "ev" });
+process(() => { forSample((i) => {
+  if (input.ch(0)[i] > 0) { const z = f32(1); ev.emit({ atSample: i, x: z }); }
+}); });`;
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: symmetric if-else writing two DIFFERENT states (target mismatch)", () => {
+  // Both branches are state writes but to different slots, so the symmetric-write
+  // shape does not match — the two targets are not the same.
+  const src = mono(
+    "const s = state.f32(0).named('s');\nconst t = state.f32(0).named('t');",
+    `if (input.ch(0).at(i) > 0) s.write(f32(1)); else t.write(f32(2));`,
+  );
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});
+
+test("reject: symmetric if-else writing the SAME buffer at DIFFERENT indices", () => {
+  // Same buffer, but `buf[i]` vs `buf[head]` are different index expressions, so the
+  // write targets are not identical.
+  const src = mono(
+    "const buf = state.buffer.f32({ size: 8 }).named('buf');\nconst head = state.i32(0).named('head');",
+    `if (input.ch(0).at(i) > 0) buf[i] = f32(1); else buf[head] = f32(2);`,
+  );
+  expect(lowerErrorId(src)).toBe("uwk-unsupported-if");
+});

--- a/packages/lang/src/__sugar__/index-channel.test.ts
+++ b/packages/lang/src/__sugar__/index-channel.test.ts
@@ -25,7 +25,7 @@
 
 import { expect, test } from "vite-plus/test";
 
-import { expectSameLowering, renderLowered } from "../goldenHarness.ts";
+import { expectSameLowering, lower, renderLowered } from "../goldenHarness.ts";
 
 const SR = 48000;
 const DUR = 128 / SR;
@@ -356,4 +356,33 @@ test("behavioral: last-write-wins semantics through the sugar", async () => {
     { sampleRate: SR, duration: DUR, inputs: { main: [x] } },
   );
   expect(r.outputs.main![0]![0]).toBeCloseTo(-0.6, 5); // second write wins
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// index sugar by object KIND — an element access whose object is neither a
+// writable output channel / buffer (for a write) nor a readable input channel /
+// param / buffer (for a read) is NOT a recognized index shape, so the index pass
+// leaves the assignment / access alone (only the inner access read-lowers).
+// ───────────────────────────────────────────────────────────────────────────
+
+test("an assignment whose LHS object is an INPUT channel is not an index write", () => {
+  // `input.ch(0)[i] = v` — the object is an input channel (read-only), so the write
+  // shape does not match; the `[i]` read-lowers to `.at(i)` but the `= v` stays.
+  const lowered = lower(
+    mono("", `input.ch(0)[i] = f32(1); out.ch(0).at(i).write(input.ch(0).at(i));`),
+  );
+  expect(lowered).toContain(`input.ch(0).at(i) = `);
+  expect(lowered).not.toContain(`input.ch(0).write(`);
+});
+
+test("reading an OUTPUT channel element has no read form and is left verbatim", () => {
+  // `out.ch(0)[i]` as a value — an output channel is write-only, so there is no
+  // `.at`/`.read` read rewrite; the element access stays as written.
+  const lowered = lower(
+    mono(
+      "const s = state.f32(0).named('s');",
+      `s.write(f32(out.ch(0)[i])); out.ch(0).at(i).write(s.read());`,
+    ),
+  );
+  expect(lowered).toContain(`out.ch(0)[i]`);
 });

--- a/packages/lang/src/__sugar__/prev.test.ts
+++ b/packages/lang/src/__sugar__/prev.test.ts
@@ -955,3 +955,170 @@ const s = createSubgraph(sg, { name: "s" });`,
   expect(got[1]!).toBeCloseTo(fr(fr(0.2) + fr(fr(0.2) * 0.5)), 5);
   expect(got[N - 1]!).toBeCloseTo(0.4, 3);
 });
+
+// ───────────────────── slot-type edge cases (un-annotated / side-effect) ─────
+// $prev methods whose slot type cannot be read from a return-type annotation or a
+// resolvable return-expression type fall back through the parameter, then to f32.
+
+test("SEMANTIC un-annotated $prev method with no return: the slot never advances", async () => {
+  // The method uses $prev only for a side-effect write and has NO `return`, so the
+  // store-then-return wrapper never runs — the slot holds its initial 0 forever and
+  // `$prev` reads 0 every sample. The slot scalar comes from the i32 parameter, so
+  // the integer recurrence stays exact.
+  const got = await renderMono(
+    `
+const acc = state.i32(0).named("acc");
+const sg = defineSubgraph(() => ({
+  bump: (step: Node<"i32">) => { acc.write(($prev + step) % 4); },
+}));
+const s = createSubgraph(sg, { name: "s" });`,
+    `s.bump(i32(1));\nout.ch(0).at(i).write(f32(acc.read()));`,
+    block(0),
+  );
+  // $prev stays 0 (no return advances it): acc = (0 + 1) % 4 = 1 every sample.
+  for (let n = 0; n < N; n++) expect(got[n]!).toBe(1);
+});
+
+test("STRUCT a no-param, un-annotated $prev method falls all the way back to an f32 slot", async () => {
+  // No return-type annotation, the return expression (`$prev`) types as the broad
+  // ambient `Node<ScalarType>` (no concrete scalar), and there is no parameter — so
+  // the slot scalar defaults to f32. The explicit form spells the f32 slot out.
+  const sugar = mono(
+    `
+const sg = defineSubgraph(() => ({
+  tick: () => $prev,
+}));
+const s = createSubgraph(sg, { name: "s" });`,
+    `out.ch(0).at(i).write(s.tick());`,
+  );
+  const explicit = mono(
+    `
+const sg = defineSubgraph(() => {
+  const __prev_0 = state.f32(0);
+  return {
+    tick: () => {
+      const __r = __prev_0.read();
+      __prev_0.write(__r);
+      return __r;
+    },
+  };
+});
+const s = createSubgraph(sg, { name: "s" });`,
+    `out.ch(0).at(i).write(s.tick());`,
+  );
+  await expectSameLowering(sugar, explicit);
+});
+
+test("STRUCT $prev method with a NON-Node return annotation ≡ explicit i32 slot", async () => {
+  // A return-type annotation that is not a `Node<'X'>` brand cannot pin the slot, so
+  // the pass falls through to the i32 parameter. The explicit form spells the i32 slot.
+  const sugar = mono(
+    `
+const sg = defineSubgraph(() => ({
+  run: (x: Node<"i32">): unknown => $prev + x,
+}));
+const s = createSubgraph(sg, { name: "s" });`,
+    `out.ch(0).at(i).write(f32(s.run(i32(1))));`,
+  );
+  const explicit = mono(
+    `
+const sg = defineSubgraph(() => {
+  const __prev_0 = state.i32(0);
+  return {
+    run: (x: Node<"i32">): unknown => {
+      const __r = __prev_0.read().add(x);
+      __prev_0.write(__r);
+      return __r;
+    },
+  };
+});
+const s = createSubgraph(sg, { name: "s" });`,
+    `out.ch(0).at(i).write(f32(s.run(i32(1))));`,
+  );
+  await expectSameLowering(sugar, explicit);
+});
+
+test("STRUCT a nested closure return inside a $prev method is NOT slot-wrapped", async () => {
+  // `wrapReturns` must stop at function boundaries: the inner `() => 1` closure's
+  // return belongs to the closure, not the method, so only the method's own return
+  // stores the slot. The explicit form keeps the closure's `return 1` untouched.
+  const sugar = mono(
+    `
+const sg = defineSubgraph(() => ({
+  run: (x: Node<"f32">) => {
+    const k = (() => 1)();
+    return x + $prev * f32(k);
+  },
+}));
+const s = createSubgraph(sg, { name: "s" });`,
+    `out.ch(0).at(i).write(s.run(input.ch(0).at(i)));`,
+  );
+  const explicit = mono(
+    `
+const sg = defineSubgraph(() => {
+  const __prev_0 = state.f32(0);
+  return {
+    run: (x: Node<"f32">) => {
+      const k = (() => 1)();
+      const __r = x.add(__prev_0.read().mul(f32(k)));
+      __prev_0.write(__r);
+      return __r;
+    },
+  };
+});
+const s = createSubgraph(sg, { name: "s" });`,
+    `out.ch(0).at(i).write(s.run(input.ch(0).at(i)));`,
+  );
+  await expectSameLowering(sugar, explicit);
+});
+
+// ───────────────────── subgraphs the $prev pass leaves untouched ─────────────
+// A `defineSubgraph` whose factory does not return an object-literal of methods, or
+// is not an inline arrow, carries no `$prev` slot — the pass passes it through.
+
+test("a defineSubgraph factory with a block body and no return is passed through", () => {
+  // The factory block has no `return`, so there is no methods object to scan — the
+  // pass must leave the call as-is rather than crash.
+  const src = mono(
+    `
+const weird = defineSubgraph((k: Node<"f32">) => {
+  const unused = k;
+});`,
+    `out.ch(0).at(i).write(input.ch(0).at(i));`,
+  );
+  const lowered = lower(src);
+  expect(lowered).toContain("defineSubgraph");
+  expect(lowered).not.toContain("__prev_");
+});
+
+test("a defineSubgraph factory that returns a non-object value is passed through", () => {
+  // Block-bodied `=> { return k; }` and concise `=> k` both return a non-object, so
+  // there is no methods object and no slot to inject.
+  const blockForm = mono(
+    `const a = defineSubgraph((k: Node<"f32">) => { return k; });`,
+    `out.ch(0).at(i).write(input.ch(0).at(i));`,
+  );
+  const conciseForm = mono(
+    `const b = defineSubgraph((k: Node<"f32">) => k);`,
+    `out.ch(0).at(i).write(input.ch(0).at(i));`,
+  );
+  expect(lower(blockForm)).toContain("defineSubgraph");
+  expect(lower(blockForm)).not.toContain("__prev_");
+  expect(lower(conciseForm)).toContain("defineSubgraph");
+  expect(lower(conciseForm)).not.toContain("__prev_");
+});
+
+test("a defineSubgraph whose factory is a named reference (not an inline arrow) is passed through", () => {
+  // `defineSubgraph(factory)` cannot be scanned for `$prev` (the arrow lives in a
+  // separate binding), so the pass leaves it untouched.
+  const src = mono(
+    `
+const factory = (k: Node<"f32">) => ({ run: (x: Node<"f32">) => k * x });
+const sg = defineSubgraph(factory);
+const s = createSubgraph(sg, f32(0.5), { name: "s" });`,
+    `out.ch(0).at(i).write(s.run(input.ch(0).at(i)));`,
+  );
+  const lowered = lower(src);
+  expect(lowered).toContain("defineSubgraph(factory)");
+  expect(lowered).not.toContain("__prev_");
+});

--- a/packages/lang/src/ide/languagePlugin.test.ts
+++ b/packages/lang/src/ide/languagePlugin.test.ts
@@ -217,6 +217,38 @@ process(() => { forSample((i) => { out.ch(0)[i] = f32(m.run(i32(1))); }); });`;
   expect(diagnostics(src)).toEqual([]);
 });
 
+// ───────────────────────── guarded emit (if-sugar shape 3) ──────────────────
+// `if (dspCond) port.emit(payload)` lowers to `port.emitIf(cond, payload)` — the
+// worklet EventDecl exposes only `emitIf`, so a verbatim `emit` draws a bogus
+// "Property 'emit' does not exist". The editor must mirror the lowering.
+
+test("a guarded emit `if (c) ev.emit(p)` reports NO diagnostics", () => {
+  const src = `const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const ev = event<{ level: number }>({ to: "main", name: "ev" });
+process(() => {
+  forSample((i) => {
+    if (input.ch(0)[i] > 0) ev.emit({ atSample: i, level: input.ch(0)[i] });
+    out.ch(0)[i] = input.ch(0)[i];
+  });
+});`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
+test("a guarded multi-emit block `if (c) { a.emit(); b.emit(); }` reports NO diagnostics", () => {
+  const src = `const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const a = event<{ x: number }>({ to: "main", name: "a" });
+const b = event<{ y: number }>({ to: "main", name: "b" });
+process(() => {
+  forSample((i) => {
+    if (input.ch(0)[i] > 0) { a.emit({ atSample: i, x: f32(1) }); b.emit({ atSample: i, y: f32(2) }); }
+    out.ch(0)[i] = input.ch(0)[i];
+  });
+});`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
 // ───────────────────────── real type errors surface, mapped to source ───────
 
 test("assigning a bool Node to an f32 output channel is a mapped error on the value", () => {

--- a/packages/lang/src/ide/languagePlugin.test.ts
+++ b/packages/lang/src/ide/languagePlugin.test.ts
@@ -166,6 +166,57 @@ process(() => {
   expect(diagnostics(src)).toEqual([]);
 });
 
+// ───────────────────────── $prev carries its concrete scalar ────────────────
+// The lowering rewrites `$prev` inside a defineSubgraph method to a typed slot
+// read (`state.<scalar>(0).read()` → Node<scalar>), so the editor must give `$prev`
+// that same concrete scalar — NOT the broad ambient `Node<ScalarType>`. Without it,
+// valid feedback that `lower()` compiles cleanly draws bogus operator / assignment
+// errors. The scalar follows the same rule the build uses (return annotation, else
+// return-expression type, else first `Node<T>` param, else f32).
+
+test("a one-pole $prev feedback written to an f32 channel reports NO diagnostics", () => {
+  const src = `const onepole = defineSubgraph((coef: Node<"f32">) => ({
+  process: (x: Node<"f32">) => coef * x + (1 - coef) * $prev,
+}));
+const lp = createSubgraph(onepole, f32(0.5), { name: "lp" });
+const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+process(() => { forSample((i) => { out.ch(0)[i] = lp.process(input.ch(0)[i]); }); });`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
+test('a $prev method with a Node<"f32"> return annotation reports NO diagnostics', () => {
+  // bool param, f32 return: the slot scalar follows the RETURN, so $prev is f32.
+  const src = `const decay = defineSubgraph(() => ({
+  run: (trigger: Node<"bool">): Node<"f32"> => select(trigger, f32(1), $prev * 0.95),
+}));
+const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const d = createSubgraph(decay, { name: "d" });
+process(() => { forSample((i) => { out.ch(0)[i] = d.run(input.ch(0)[i] > 0.5); }); });`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
+test("a $prev method with an f64 return annotation reports NO diagnostics", () => {
+  const src = `const acc = defineSubgraph(() => ({
+  step: (): Node<"f64"> => $prev.mul(f64(0.5)).add(f64(0.25)),
+}));
+const out = audioOutput({ channels: 1, name: "main" });
+const a = createSubgraph(acc, { name: "a" });
+process(() => { forSample((i) => { out.ch(0)[i] = f32(a.step()); }); });`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
+test("an i32 accumulator's $prev (slot scalar from the param) reports NO diagnostics", () => {
+  const src = `const sg = defineSubgraph(() => ({
+  run: (k: Node<"i32">) => k + $prev,
+}));
+const m = createSubgraph(sg, { name: "m" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => { forSample((i) => { out.ch(0)[i] = f32(m.run(i32(1))); }); });`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
 // ───────────────────────── real type errors surface, mapped to source ───────
 
 test("assigning a bool Node to an f32 output channel is a mapped error on the value", () => {

--- a/packages/lang/src/ide/languagePlugin.test.ts
+++ b/packages/lang/src/ide/languagePlugin.test.ts
@@ -1,0 +1,284 @@
+/**
+ * End-to-end IDE behavior over a headless Volar TypeScript language service — the
+ * exact pipeline an editor runs. A `.uwk.ts` fixture is type-checked through the
+ * {@link createUwkLanguagePlugin} virtual code; every query (diagnostics, hover,
+ * completion, go-to-definition) is issued at the AUTHOR's source position and the
+ * result is projected back to source by Volar. These assertions are the proof that
+ * the sugar "type-checks correctly in the IDE" without a `// @ts-nocheck` header.
+ */
+
+import { createLanguage, type SourceScript } from "@volar/language-core";
+import {
+  createProxyLanguageService,
+  decorateLanguageServiceHost,
+  resolveFileLanguageId,
+} from "@volar/typescript";
+import ts from "typescript";
+import { expect, test } from "vite-plus/test";
+
+import { AMBIENT_DTS } from "../ambient.ts";
+import { createUwkLanguagePlugin } from "./languagePlugin.ts";
+
+const DIR = import.meta.dirname;
+const AMBIENT_PATH = `${DIR}/__uwk_ambient__.d.ts`;
+
+const COMPILER_OPTIONS: ts.CompilerOptions = {
+  target: ts.ScriptTarget.ESNext,
+  lib: ["lib.es2023.d.ts"],
+  module: ts.ModuleKind.NodeNext,
+  moduleResolution: ts.ModuleResolutionKind.NodeNext,
+  customConditions: ["development"],
+  allowImportingTsExtensions: true,
+  noEmit: true,
+  skipLibCheck: true,
+  strict: false,
+  esModuleInterop: true,
+};
+
+// One Volar-decorated TS language service, built lazily and shared across the
+// suite. It loads the lib + `@unworklet/core` type surface ONCE and serves every
+// fixture as a distinct in-memory `.uwk.ts` file, so per-test cost is an
+// incremental program update rather than a full type-environment reload — which
+// keeps the suite fast enough not to starve the heavier snapshot tests under
+// parallel coverage.
+const fixtures = new Map<string, string>();
+let projectVersion = 0;
+let fixtureCounter = 0;
+
+const sharedLs: ts.LanguageService = (() => {
+  const snapshotText = (fileName: string): string | undefined =>
+    fileName === AMBIENT_PATH ? AMBIENT_DTS : (fixtures.get(fileName) ?? ts.sys.readFile(fileName));
+  const host: ts.LanguageServiceHost = {
+    getCompilationSettings: () => COMPILER_OPTIONS,
+    getScriptFileNames: () => [AMBIENT_PATH, ...fixtures.keys()],
+    getProjectVersion: () => String(projectVersion),
+    getScriptVersion: () => "0",
+    getScriptSnapshot: (fileName) => {
+      const text = snapshotText(fileName);
+      return text === undefined ? undefined : ts.ScriptSnapshot.fromString(text);
+    },
+    getCurrentDirectory: () => DIR,
+    getDefaultLibFileName: (o) => ts.getDefaultLibFilePath(o),
+    fileExists: (fileName) =>
+      fileName === AMBIENT_PATH || fixtures.has(fileName) || ts.sys.fileExists(fileName),
+    readFile: (fileName) => snapshotText(fileName),
+    readDirectory: (path, exts, exclude, include, depth) =>
+      ts.sys.readDirectory(path, exts, exclude, include, depth),
+    directoryExists: (dir) => ts.sys.directoryExists(dir),
+    getDirectories: (dir) => ts.sys.getDirectories(dir),
+    realpath: (p) => ts.sys.realpath?.(p) ?? p,
+  };
+
+  // Capture the UNDECORATED snapshot getter: `decorateLanguageServiceHost` wraps
+  // `getScriptSnapshot` to route through the language, so the sync callback must
+  // use the original or it recurses into the decoration forever.
+  const getScriptSnapshot = host.getScriptSnapshot.bind(host);
+  const language = createLanguage<string>(
+    [createUwkLanguagePlugin(ts), { getLanguageId: resolveFileLanguageId }],
+    new Map<string, SourceScript<string>>(),
+    (fileName) => {
+      const snapshot = getScriptSnapshot(fileName);
+      if (snapshot) language.scripts.set(fileName, snapshot);
+      else language.scripts.delete(fileName);
+    },
+  );
+  decorateLanguageServiceHost(ts, language, host);
+  const proxied = createProxyLanguageService(ts.createLanguageService(host));
+  proxied.initialize(language);
+  return proxied.proxy;
+})();
+
+/** Register `source` as a fresh `.uwk.ts` file in the shared service. */
+function service(source: string): { ls: ts.LanguageService; fileName: string } {
+  const fileName = `${DIR}/__fixture_${fixtureCounter++}__.uwk.ts`;
+  fixtures.set(fileName, source);
+  projectVersion += 1;
+  return { ls: sharedLs, fileName };
+}
+
+type SimpleDiag = { message: string; span: string | undefined };
+
+function diagnostics(source: string): SimpleDiag[] {
+  const { ls, fileName } = service(source);
+  return ls.getSemanticDiagnostics(fileName).map((d) => ({
+    message: ts.flattenDiagnosticMessageText(d.messageText, " "),
+    span:
+      d.start !== undefined && d.length !== undefined
+        ? source.slice(d.start, d.start + d.length)
+        : undefined,
+  }));
+}
+
+/** The 1-based offset of the FIRST occurrence of `needle`, plus an in-token nudge. */
+function at(source: string, needle: string, nudge = 1): number {
+  const i = source.indexOf(needle);
+  if (i < 0) throw new Error(`needle not found: ${needle}`);
+  return i + nudge;
+}
+
+// ───────────────────────── valid sugar → zero diagnostics ───────────────────
+
+test("valid stereo-gain Tier B sugar reports NO diagnostics (no @ts-nocheck needed)", () => {
+  const src = `const input = audioInput({ channels: 2 });
+const out = audioOutput({ channels: 2 });
+const gain = param.f32({ default: 1, min: 0, max: 4, automationRate: "a-rate" });
+const meterL = state.f32(0).expose({ publish: { rateFps: 30 } });
+process(() => {
+  forSample((i) => {
+    const l = input.left[i] * gain[i];
+    out.left[i] = l;
+    meterL.write(max(abs(l), meterL));
+  });
+  meterL.write(meterL * 0.95);
+});`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
+test("valid MIDI synth (event.midi no-name, bare-state, .named(), select) reports NO diagnostics", () => {
+  const src = `const out = audioOutput({ channels: 1, name: "main" });
+const notes = event.midi({ from: "main" });
+const phase = state.f32(0).named();
+const note = state.i32(69).named();
+const gate = state.bool(false).named();
+process(() => {
+  notes.onEvent("noteOn", ({ note: n }) => { note.write(n); gate.write(true); });
+  forSample((i) => {
+    const inc = f32(note).sub(69).mul(Math.LN2 / 12).exp().mul(440 / 48000);
+    out.ch(0)[i] = sin(phase) * select(gate, 0.3, 0);
+    phase.write(phase + inc);
+  });
+});`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
+test("index read/write + buffer + ternary + comparison sugar reports NO diagnostics", () => {
+  const src = `const buf = state.buffer.f32({ size: 16 }).named();
+const input = audioInput({ channels: 1, name: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+const head = state.i32(0).named();
+process(() => {
+  forSample((i) => {
+    buf[head] = input.ch(0)[i];
+    const v = buf[i] > 0 ? buf[i] * 0.5 : -buf[i];
+    out.ch(0)[i] = v;
+  });
+});`;
+  expect(diagnostics(src)).toEqual([]);
+});
+
+// ───────────────────────── real type errors surface, mapped to source ───────
+
+test("assigning a bool Node to an f32 output channel is a mapped error on the value", () => {
+  const src = `const gate = state.bool(false).named();
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => {
+  forSample((i) => {
+    out.ch(0)[i] = gate;
+  });
+});`;
+  const diags = diagnostics(src);
+  expect(diags.length).toBe(1);
+  expect(diags[0]!.message).toContain('Node<"bool">');
+  expect(diags[0]!.message).toContain('Node<"f32">');
+  // The error projects back onto the author's `gate`, not into generated glue.
+  expect(diags[0]!.span).toContain("gate");
+});
+
+test("calling a non-existent method on a Node is a mapped error", () => {
+  const src = `const input = audioInput({ channels: 1, name: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => {
+  forSample((i) => {
+    out.ch(0)[i] = input.ch(0)[i].notAMethod();
+  });
+});`;
+  const diags = diagnostics(src);
+  expect(diags.some((d) => d.message.includes("notAMethod"))).toBe(true);
+});
+
+test("a misspelled declaration identifier is a mapped error at the use site", () => {
+  const src = `const input = audioInput({ channels: 1, name: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => {
+  forSample((i) => {
+    out.ch(0)[i] = inputt.ch(0)[i] * 2;
+  });
+});`;
+  const diags = diagnostics(src);
+  expect(diags.some((d) => d.message.includes("inputt") && d.span === "inputt")).toBe(true);
+});
+
+// ───────────────────────── hover ────────────────────────────────────────────
+
+test("hover on a sugar-multiplied binding reports its Node type", () => {
+  const src = `const input = audioInput({ channels: 1, name: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => {
+  forSample((i) => {
+    const wet = input.ch(0)[i] * 2;
+    out.ch(0)[i] = wet;
+  });
+});`;
+  const { ls, fileName } = service(src);
+  const info = ls.getQuickInfoAtPosition(fileName, at(src, "wet", 1));
+  const display = info?.displayParts?.map((p) => p.text).join("") ?? "";
+  expect(display).toContain("wet");
+  expect(display).toContain('Node<"f32">');
+});
+
+test("hover on a declaration handle reports its DSL type", () => {
+  const src = `const cutoff = param.f32({ default: 1, min: 0, max: 4, automationRate: "a-rate" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => {
+  forSample((i) => {
+    out.ch(0)[i] = cutoff[i];
+  });
+});`;
+  const { ls, fileName } = service(src);
+  // hover the `cutoff` use inside the process body
+  const info = ls.getQuickInfoAtPosition(fileName, at(src, "cutoff[i]", 1));
+  const display = info?.displayParts?.map((p) => p.text).join("") ?? "";
+  expect(display).toContain("Param");
+});
+
+// ───────────────────────── completion ───────────────────────────────────────
+
+test("completion after `input.` offers the stereo channel-view members", () => {
+  const src = `const input = audioInput({ channels: 2 });
+const out = audioOutput({ channels: 2 });
+process(() => {
+  forSample((i) => {
+    out.left[i] = input.left[i];
+  });
+});`;
+  const { ls, fileName } = service(src);
+  // position right after the dot in the FIRST `input.left`
+  const dot = src.indexOf("input.") + "input.".length;
+  const completions = ls.getCompletionsAtPosition(fileName, dot, undefined);
+  const names = completions?.entries.map((e) => e.name) ?? [];
+  expect(names).toContain("left");
+  expect(names).toContain("right");
+  expect(names).toContain("ch");
+});
+
+// ───────────────────────── go to definition ─────────────────────────────────
+
+test("go-to-definition on a sugar operand jumps to the declaration in source", () => {
+  const src = `const gain = param.f32({ default: 1, min: 0, max: 4, automationRate: "a-rate" });
+const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+process(() => {
+  forSample((i) => {
+    out.ch(0)[i] = input.ch(0)[i] * gain[i];
+  });
+});`;
+  const { ls, fileName } = service(src);
+  const useOffset = src.lastIndexOf("gain[i]") + 1;
+  const defs = ls.getDefinitionAtPosition(fileName, useOffset);
+  expect(defs?.length).toBeGreaterThan(0);
+  const def = defs![0]!;
+  expect(def.fileName).toBe(fileName);
+  // the definition span lands on the `gain` declaration binding (offset of `const gain`)
+  expect(src.slice(def.textSpan.start, def.textSpan.start + def.textSpan.length)).toBe("gain");
+  expect(def.textSpan.start).toBe(src.indexOf("const gain") + "const ".length);
+});

--- a/packages/lang/src/ide/languagePlugin.test.ts
+++ b/packages/lang/src/ide/languagePlugin.test.ts
@@ -249,6 +249,23 @@ process(() => {
   expect(diagnostics(src)).toEqual([]);
 });
 
+test("a guarded block mixing an emit with a write is NOT silently accepted (build rejects it)", () => {
+  // The build's `detectEmits` only accepts an all-emits then-branch; a block mixing
+  // an emit with a state write throws `uwk-unsupported-if`. The editor must mirror
+  // that — leave `emit` unrewritten so its `Property 'emit' does not exist` surfaces,
+  // rather than green-light a `.uwk.ts` the build will reject.
+  const src = `const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const ev = event<{ level: number }>({ to: "main", name: "ev" });
+const s = state.f32(0).named("s");
+process(() => {
+  forSample((i) => {
+    if (input.ch(0)[i] > 0) { ev.emit({ atSample: i, level: input.ch(0)[i] }); s.write(f32(1)); }
+  });
+});`;
+  expect(diagnostics(src).some((d) => d.message.includes("emit"))).toBe(true);
+});
+
 // ───────────────────────── real type errors surface, mapped to source ───────
 
 test("assigning a bool Node to an f32 output channel is a mapped error on the value", () => {

--- a/packages/lang/src/ide/languagePlugin.ts
+++ b/packages/lang/src/ide/languagePlugin.ts
@@ -1,0 +1,70 @@
+/**
+ * The Volar {@link LanguagePlugin} for `.uwk.ts` files. It teaches any Volar-based
+ * TypeScript tool (the editor TS-server plugin, a `tsc`-style CLI, a headless test
+ * program) to type-check a `.uwk.ts` against its desugared virtual TypeScript
+ * ({@link generateVirtualCode}) and project diagnostics / hover / completion /
+ * definitions back to the author's source through the generated mappings.
+ *
+ * A `.uwk.ts` file already carries the `.ts` extension, so TypeScript includes it
+ * in the program natively — this plugin only swaps its content for the virtual
+ * code. `preventLeadingOffset` keeps the generated offsets identical to the
+ * mappings (no whitespace prefix), so positions line up 1:1.
+ */
+
+import type { LanguagePlugin } from "@volar/language-core";
+import type { TypeScriptServiceScript } from "@volar/typescript";
+
+import type { FsSnapshot } from "../program.ts";
+import { generateVirtualCode } from "./virtualCode.ts";
+
+/** The Volar language id assigned to `.uwk.ts` source scripts. */
+export const UWK_LANGUAGE_ID = "uwk";
+
+export function isUwkScript(scriptId: string): boolean {
+  return scriptId.endsWith(".uwk.ts");
+}
+
+export type UwkLanguagePluginOptions = {
+  /**
+   * A captured file-system snapshot for the type-directed analysis, for hosts
+   * without disk access (the browser). Node hosts omit it (disk-backed).
+   */
+  snapshot?: FsSnapshot;
+};
+
+export function createUwkLanguagePlugin(
+  ts: typeof import("typescript"),
+  options: UwkLanguagePluginOptions = {},
+): LanguagePlugin<string> {
+  return {
+    getLanguageId(scriptId) {
+      return isUwkScript(scriptId) ? UWK_LANGUAGE_ID : undefined;
+    },
+    createVirtualCode(_scriptId, languageId, snapshot) {
+      if (languageId !== UWK_LANGUAGE_ID) return undefined;
+      const source = snapshot.getText(0, snapshot.getLength());
+      const { code, mappings } = generateVirtualCode(source, { snapshot: options.snapshot });
+      return {
+        id: "main",
+        languageId: "typescript",
+        snapshot: {
+          getText: (start, end) => code.slice(start, end),
+          getLength: () => code.length,
+          getChangeRange: () => undefined,
+        },
+        mappings,
+      };
+    },
+    typescript: {
+      extraFileExtensions: [],
+      getServiceScript(root): TypeScriptServiceScript {
+        return {
+          code: root,
+          extension: ".ts",
+          scriptKind: ts.ScriptKind.TS,
+          preventLeadingOffset: true,
+        };
+      },
+    },
+  };
+}

--- a/packages/lang/src/ide/tsserverPlugin.test.ts
+++ b/packages/lang/src/ide/tsserverPlugin.test.ts
@@ -1,0 +1,219 @@
+/**
+ * The real editor path, end to end. VS Code drives a `tsserver` process over its
+ * JSON protocol; this test does the same — it spawns the actual `tsserver`, loads
+ * the BUILT `@unworklet/lang/typescript-plugin` through a project's `tsconfig`
+ * `plugins`, opens `.uwk.ts` files, and asserts the responses a real editor shows:
+ * zero diagnostics on valid sugar, a real type error on a genuine mistake, hover
+ * type, and member completion.
+ *
+ * This exercises the parts the in-process language-service tests cannot — tsserver
+ * plugin RESOLUTION (which uses a legacy resolver that ignores `exports` and
+ * `.cjs`, so the plugin must ship as `typescript-plugin/index.js` + a CommonJS
+ * `package.json`) and ambient INCLUSION (a `node_modules` `.d.ts` only loads via
+ * `files`, never `include`). Both broke the editor while the in-process tests
+ * stayed green, which is why this lives here.
+ */
+
+import { spawn, type ChildProcessByStdio } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Readable, Writable } from "node:stream";
+
+import { build } from "esbuild";
+import { afterAll, beforeAll, expect, test } from "vite-plus/test";
+
+import { AMBIENT_DTS } from "../ambient.ts";
+
+const LANG = path.resolve(import.meta.dirname, "../..");
+const REPO = path.resolve(LANG, "../..");
+const CORE = path.join(REPO, "packages/core");
+const TS_DIR = path.join(LANG, "node_modules/typescript");
+const TSSERVER = path.join(TS_DIR, "lib/tsserver.js");
+
+const VALID = `const input = audioInput({ channels: 2 });
+const out = audioOutput({ channels: 2 });
+const gain = param.f32({ default: 1, min: 0, max: 4, automationRate: "a-rate" });
+process(() => {
+  forSample((i) => {
+    const l = input.left[i] * gain[i];
+    out.left[i] = l;
+    out.right[i] = input.right[i] * gain[i];
+  });
+});`;
+
+const BROKEN = `const out = audioOutput({ channels: 2 });
+const gate = state.bool(false).named();
+process(() => {
+  forSample((i) => {
+    out.left[i] = gate;
+  });
+});`;
+
+let dir: string;
+
+/** A minimal tsserver protocol client: newline-delimited requests, Content-Length
+ * framed responses; correlate by `request_seq`. */
+class TsServer {
+  private readonly proc: ChildProcessByStdio<Writable, Readable, null>;
+  private seq = 0;
+  private buf = "";
+  private readonly waiters = new Map<number, (m: { body?: unknown }) => void>();
+
+  constructor(cwd: string) {
+    this.proc = spawn("node", [TSSERVER], { cwd, stdio: ["pipe", "pipe", "ignore"] });
+    this.proc.stdout.setEncoding("utf8");
+    this.proc.stdout.on("data", (chunk: string) => {
+      this.buf += chunk;
+      for (;;) {
+        const header = this.buf.match(/Content-Length: (\d+)\r\n\r\n/);
+        if (!header) break;
+        const start = header.index! + header[0].length;
+        const end = start + Number(header[1]);
+        if (this.buf.length < end) break;
+        const body = this.buf.slice(start, end);
+        this.buf = this.buf.slice(end);
+        let msg: { type?: string; request_seq?: number; body?: unknown };
+        try {
+          msg = JSON.parse(body);
+        } catch {
+          continue;
+        }
+        if (msg.type === "response" && msg.request_seq !== undefined) {
+          this.waiters.get(msg.request_seq)?.(msg);
+          this.waiters.delete(msg.request_seq);
+        }
+      }
+    });
+  }
+
+  request<T = unknown>(command: string, args: unknown): Promise<{ body?: T }> {
+    const s = ++this.seq;
+    const wait = new Promise<{ body?: T }>((res) => this.waiters.set(s, res as never));
+    this.proc.stdin.write(
+      `${JSON.stringify({ seq: s, type: "request", command, arguments: args })}\n`,
+    );
+    return wait;
+  }
+
+  notify(command: string, args: unknown): void {
+    this.proc.stdin.write(
+      `${JSON.stringify({ seq: ++this.seq, type: "request", command, arguments: args })}\n`,
+    );
+  }
+
+  dispose(): void {
+    this.proc.kill();
+  }
+}
+
+const sleep = (ms: number): Promise<void> => new Promise((r) => setTimeout(r, ms));
+
+/** 1-based { line, offset } of the character at `index` in `text`. */
+function at(text: string, index: number): { line: number; offset: number } {
+  const before = text.slice(0, index);
+  return { line: before.split("\n").length, offset: index - before.lastIndexOf("\n") };
+}
+
+beforeAll(async () => {
+  // Build the plugin into its shipped on-disk shape (the legacy-resolvable
+  // `typescript-plugin/index.js` + CommonJS marker), so tsserver can load it.
+  mkdirSync(path.join(LANG, "typescript-plugin"), { recursive: true });
+  await build({
+    entryPoints: [path.join(LANG, "src/typescript-plugin.ts")],
+    outfile: path.join(LANG, "typescript-plugin/index.js"),
+    bundle: true,
+    platform: "node",
+    format: "cjs",
+    target: "node18",
+    external: ["typescript"],
+    footer: { js: "module.exports = module.exports.default;" },
+    logLevel: "silent",
+  });
+  writeFileSync(
+    path.join(LANG, "typescript-plugin/package.json"),
+    `${JSON.stringify({ type: "commonjs" })}\n`,
+  );
+
+  // A throwaway consumer project: node_modules symlinks to the real packages, the
+  // ambient pulled in via `files`, a tsconfig that registers the plugin.
+  dir = mkdtempSync(path.join(tmpdir(), "uwk-tsserver-"));
+  mkdirSync(path.join(dir, "node_modules/@unworklet"), { recursive: true });
+  symlinkSync(LANG, path.join(dir, "node_modules/@unworklet/lang"));
+  symlinkSync(CORE, path.join(dir, "node_modules/@unworklet/core"));
+  writeFileSync(path.join(dir, "uwk-ambient.d.ts"), AMBIENT_DTS);
+  writeFileSync(
+    path.join(dir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: {
+        module: "nodenext",
+        moduleResolution: "nodenext",
+        customConditions: ["development"],
+        allowImportingTsExtensions: true,
+        lib: ["es2023"],
+        strict: true,
+        noEmit: true,
+        skipLibCheck: true,
+        plugins: [{ name: "@unworklet/lang/typescript-plugin" }],
+      },
+      files: ["uwk-ambient.d.ts"],
+      include: ["."],
+    }),
+  );
+  writeFileSync(path.join(dir, "valid.uwk.ts"), VALID);
+  writeFileSync(path.join(dir, "broken.uwk.ts"), BROKEN);
+});
+
+afterAll(() => {
+  if (dir) rmSync(dir, { recursive: true, force: true });
+});
+
+type Diag = { text: string };
+
+test("a real tsserver loads the plugin and type-checks .uwk.ts sugar end to end", async () => {
+  const server = new TsServer(dir);
+  try {
+    const validPath = path.join(dir, "valid.uwk.ts");
+    const brokenPath = path.join(dir, "broken.uwk.ts");
+    server.notify("open", { file: validPath, fileContent: VALID, scriptKindName: "TS" });
+
+    // Wait for the project to load and the plugin to attach. Poll the valid file:
+    // before the plugin is live, the raw sugar reports errors; once live, none.
+    let validDiags: Diag[] = [{ text: "pending" }];
+    for (let i = 0; i < 20 && validDiags.length > 0; i++) {
+      await sleep(500);
+      const r = await server.request<Diag[]>("semanticDiagnosticsSync", { file: validPath });
+      validDiags = r.body ?? [];
+    }
+    expect(validDiags).toEqual([]); // valid sugar — no @ts-nocheck, no errors
+
+    // Hover on `l` (a sugar-multiplied binding) reports the desugared Node type.
+    const lPos = at(VALID, VALID.indexOf("const l =") + "const ".length);
+    const qi = await server.request<{ displayString?: string }>("quickinfo", {
+      file: validPath,
+      line: lPos.line,
+      offset: lPos.offset,
+    });
+    expect(qi.body?.displayString).toContain('Node<"f32">');
+
+    // Completion after `input.` offers the stereo channel-view members.
+    const cPos = at(VALID, VALID.indexOf("input.left") + "input.".length);
+    const comp = await server.request<{ entries: { name: string }[] }>("completionInfo", {
+      file: validPath,
+      line: cPos.line,
+      offset: cPos.offset,
+    });
+    const names = (comp.body?.entries ?? []).map((e) => e.name);
+    expect(names).toEqual(expect.arrayContaining(["left", "right", "ch"]));
+
+    // A genuine type error (bool Node written to an f32 output) surfaces, mapped
+    // back onto the author's `.uwk.ts`.
+    server.notify("open", { file: brokenPath, fileContent: BROKEN, scriptKindName: "TS" });
+    await sleep(500);
+    const broken = await server.request<Diag[]>("semanticDiagnosticsSync", { file: brokenPath });
+    const texts = (broken.body ?? []).map((d) => d.text);
+    expect(texts.some((t) => t.includes('Node<"bool">') && t.includes('Node<"f32">'))).toBe(true);
+  } finally {
+    server.dispose();
+  }
+});

--- a/packages/lang/src/ide/virtualCode.test.ts
+++ b/packages/lang/src/ide/virtualCode.test.ts
@@ -270,6 +270,21 @@ process(() => { forSample((i) => {
   expect(c).not.toContain("emitIf");
 });
 
+test("a guarded block mixing an emit with a non-emit statement is left verbatim", () => {
+  // The build's `detectEmits` rejects a then-branch that is not all-emits (it throws
+  // `uwk-unsupported-if`), so the IDE must NOT rewrite the emit — it stays verbatim
+  // (and keeps its `Property 'emit'` error) rather than silently type-checking.
+  const c = code(`const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const ev = event<{ level: number }>({ to: "main", name: "ev" });
+const s = state.f32(0).named("s");
+process(() => { forSample((i) => {
+  if (input.ch(0)[i] > 0) { ev.emit({ atSample: i, level: f32(1) }); s.write(f32(1)); }
+}); });`);
+  expect(c).toContain("ev.emit({");
+  expect(c).not.toContain("emitIf");
+});
+
 // ───────────────────────── auto-name (S9) for type-checking ─────────────────
 
 test("no-arg .named() is filled with the binding name", () => {

--- a/packages/lang/src/ide/virtualCode.test.ts
+++ b/packages/lang/src/ide/virtualCode.test.ts
@@ -150,7 +150,7 @@ test("a bare state read in a value position lowers to .read(); a write stays exp
   expect(c).toContain("env.write(mul(env.read(), 0.99))"); // operand reads; the write target stays
 });
 
-test("$prev is left verbatim (it is an ambient Node, not rewritten by the IDE layer)", () => {
+test("$prev is cast to the method's slot scalar (the concrete type the build lowers it to)", () => {
   const src = `const onepole = defineSubgraph((coef: Node<"f32">) => ({
   process: (x: Node<"f32">) => coef * x + (1 - coef) * $prev,
 }));
@@ -158,9 +158,29 @@ const input = audioInput({ channels: 1, name: "main" });
 const out = audioOutput({ channels: 1, name: "main" });
 process(() => { forSample((i) => { out.ch(0)[i] = input.ch(0)[i]; }); });`;
   const c = code(src);
-  expect(c).toContain("$prev");
-  // the user's explicit parens around `(1 - coef)` are preserved verbatim
-  expect(c).toContain("add(mul(coef, x), mul((sub(1, coef)), $prev))");
+  // `$prev` stays author text, wrapped in a cast to its slot scalar (here `f32`, the
+  // method's `Node<"f32">` param) so the editor sees the concrete type — the broad
+  // ambient `Node<ScalarType>` would draw a bogus operator error against the f32 ops.
+  // The user's explicit parens around `(1 - coef)` are preserved verbatim.
+  expect(c).toContain('add(mul(coef, x), mul((sub(1, coef)), ($prev as Node<"f32">)))');
+});
+
+test("$prev's slot scalar follows a return annotation, not the param (bool param, f32 return)", () => {
+  const src = `const decay = defineSubgraph(() => ({
+  run: (trigger: Node<"bool">): Node<"f32"> => select(trigger, f32(1), $prev * 0.95),
+}));
+const out = audioOutput({ channels: 1, name: "main" });
+const d = createSubgraph(decay, { name: "d" });
+process(() => { forSample((i) => { out.ch(0)[i] = 0; }); });`;
+  expect(code(src)).toContain('($prev as Node<"f32">)');
+});
+
+test("$prev outside any defineSubgraph method is left verbatim (no slot to type it)", () => {
+  // A stray `$prev` at module scope is not a feedback site — there is no method slot
+  // to give it a scalar, so the IDE leaves it untouched (it stays the ambient Node).
+  const c = code(mono("const k = $prev;", `out.ch(0)[i] = input.ch(0)[i];`));
+  expect(c).toContain("const k = $prev;");
+  expect(c).not.toContain("as Node<");
 });
 
 // ───────────────────────── auto-name (S9) for type-checking ─────────────────

--- a/packages/lang/src/ide/virtualCode.test.ts
+++ b/packages/lang/src/ide/virtualCode.test.ts
@@ -183,6 +183,34 @@ test("$prev outside any defineSubgraph method is left verbatim (no slot to type 
   expect(c).not.toContain("as Node<");
 });
 
+// ───────────────────────── guarded emit (if-sugar shape 3) ──────────────────
+
+test("a guarded emit rewrites `.emit(` to `.emitIf(true, ` (payload kept, desugared)", () => {
+  const src = `const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const ev = event<{ level: number }>({ to: "main", name: "ev" });
+process(() => { forSample((i) => {
+  if (input.ch(0)[i] > 0) ev.emit({ atSample: i, level: input.ch(0)[i] * 2 });
+}); });`;
+  const c = code(src);
+  // the real guard stays the surrounding `if`; the payload's `* 2` sugar still lowers.
+  expect(c).toContain("ev.emitIf(true, { atSample: i, level: mul(input.ch(0).at(i), 2) })");
+  expect(c).not.toContain("ev.emit(");
+});
+
+test("a bare `.emit(` outside a DSP-guarded if is left verbatim", () => {
+  // No enclosing DSP `if`, so it is not the lowering's guarded-emit shape — the IDE
+  // leaves it untouched (it stays the same `Property 'emit'` the build would reject).
+  const c = code(
+    mono(
+      "const ev = event<{ x: number }>({ to: 'main', name: 'ev' });",
+      `ev.emit({ atSample: i, x: f32(1) });`,
+    ),
+  );
+  expect(c).toContain("ev.emit({");
+  expect(c).not.toContain("emitIf");
+});
+
 // ───────────────────────── auto-name (S9) for type-checking ─────────────────
 
 test("no-arg .named() is filled with the binding name", () => {

--- a/packages/lang/src/ide/virtualCode.test.ts
+++ b/packages/lang/src/ide/virtualCode.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Unit tests for the virtual-code generator. These assert two things directly off
+ * the {@link generateVirtualCode} output (no language service):
+ *
+ *  1. DESUGAR TEXT — the sugar a `.uwk.ts` file uses is rewritten to the exact chain
+ *     primitives stock TypeScript accepts (`a * b` → `mul(a, b)`, `out[i] = v` →
+ *     `out.at(i).write(v)`, a bare `state` read → `state.read()`, …), and only those.
+ *  2. MAPPINGS — every author-written span maps back 1:1 (so hover / rename / errors
+ *     land on the real token), and injected glue maps as a zero-width verification
+ *     anchor (so diagnostics still project back, invisibly to navigation).
+ */
+
+import type { CodeMapping } from "@volar/language-core";
+import { expect, test } from "vite-plus/test";
+
+import { generateVirtualCode, type VirtualCodeResult } from "./virtualCode.ts";
+
+/** A mono processor body around `decls` + per-sample `body`. */
+function mono(decls: string, body: string): string {
+  return `const input = audioInput({ channels: 1, name: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+${decls}process(() => {
+  forSample((i) => {
+${body}
+  });
+});`;
+}
+
+const gen = (src: string): VirtualCodeResult => generateVirtualCode(src);
+const code = (src: string): string => gen(src).code;
+
+/** A verbatim (author) mapping vs. an injected (synthetic) one. */
+const isSynth = (m: CodeMapping): boolean => m.generatedLengths !== undefined;
+
+/** Map a source offset through the FULL (verbatim) mappings to a generated offset. */
+function toGenerated(result: VirtualCodeResult, sourceOffset: number): number {
+  for (const m of result.mappings) {
+    if (isSynth(m)) continue;
+    const so = m.sourceOffsets[0]!;
+    const len = m.lengths[0]!;
+    if (sourceOffset >= so && sourceOffset < so + len) {
+      return m.generatedOffsets[0]! + (sourceOffset - so);
+    }
+  }
+  return -1;
+}
+
+// ───────────────────────── operator desugaring ──────────────────────────────
+
+test("arithmetic operators lower to the chain primitive call", () => {
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] + 1;`))).toContain(
+    "out.ch(0).at(i).write(add(input.ch(0).at(i), 1))",
+  );
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] * 2;`))).toContain(
+    "write(mul(input.ch(0).at(i), 2))",
+  );
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] - 3;`))).toContain(
+    "sub(input.ch(0).at(i), 3)",
+  );
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] / 4;`))).toContain(
+    "div(input.ch(0).at(i), 4)",
+  );
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] % 5;`))).toContain(
+    "mod(input.ch(0).at(i), 5)",
+  );
+});
+
+test("precedence is preserved by nesting, left-associative", () => {
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] * 2 + 1;`))).toContain(
+    "add(mul(input.ch(0).at(i), 2), 1)",
+  );
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] - 1 - 2;`))).toContain(
+    "sub(sub(input.ch(0).at(i), 1), 2)",
+  );
+});
+
+test("comparison operators lower; != negates eq", () => {
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] > 0 ? 1 : 0;`))).toContain(
+    "gt(input.ch(0).at(i), 0)",
+  );
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] >= 0 ? 1 : 0;`))).toContain("gte(");
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] <= 0 ? 1 : 0;`))).toContain("lte(");
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i] < 0 ? 1 : 0;`))).toContain("lt(");
+  const ne = code(mono("const s = state.bool(false).named();", `s.write(input.ch(0)[i] != 0);`));
+  expect(ne).toContain("not(eq(input.ch(0).at(i), 0))");
+});
+
+test("unary minus and logical not lower; ternary lowers to select", () => {
+  expect(code(mono("", `out.ch(0)[i] = -input.ch(0)[i];`))).toContain("neg(input.ch(0).at(i))");
+  const tern = code(
+    mono("", `out.ch(0)[i] = input.ch(0)[i] > 0 ? input.ch(0)[i] : -input.ch(0)[i];`),
+  );
+  expect(tern).toContain(
+    "select(gt(input.ch(0).at(i), 0), input.ch(0).at(i), neg(input.ch(0).at(i)))",
+  );
+  const bnot = code(mono("const b = state.bool(false).named();", `out.ch(0)[i] = !b ? 1 : 0;`));
+  expect(bnot).toContain("not(b.read())");
+});
+
+test("number op number is NOT lowered (stays build-time JS)", () => {
+  const c = code(mono("", `out.ch(0)[i] = input.ch(0)[i] * (2 + 3);`));
+  expect(c).toContain("mul(input.ch(0).at(i), (2 + 3))");
+  expect(c).not.toContain("add(2, 3)");
+});
+
+// ───────────────────────── index access desugaring ──────────────────────────
+
+test("index read lowers by object kind: channel/param → at, buffer → read", () => {
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i];`))).toContain("input.ch(0).at(i)");
+  expect(
+    code(
+      mono(
+        'const g = param.f32({ default: 1, min: 0, max: 4, automationRate: "a-rate" });',
+        `out.ch(0)[i] = g[i];`,
+      ),
+    ),
+  ).toContain("g.at(i)");
+  expect(
+    code(mono("const buf = state.buffer.f32({ size: 8 }).named();", `out.ch(0)[i] = buf[i];`)),
+  ).toContain("buf.read(i)");
+});
+
+test("index write lowers: output channel → at().write(), buffer → write()", () => {
+  expect(code(mono("", `out.ch(0)[i] = input.ch(0)[i];`))).toContain(
+    "out.ch(0).at(i).write(input.ch(0).at(i))",
+  );
+  const buf = code(
+    mono("const buf = state.buffer.f32({ size: 8 }).named();", `buf[i] = input.ch(0)[i];`),
+  );
+  expect(buf).toContain("buf.write(i, input.ch(0).at(i))");
+});
+
+test("a non-DSL element access is left verbatim (real array indexing untouched)", () => {
+  const c = code(mono("const arr = [1, 2, 3];", `out.ch(0)[i] = input.ch(0)[i] * arr[0];`));
+  expect(c).toContain("arr[0]");
+  expect(c).not.toContain("arr.at(0)");
+  expect(c).not.toContain("arr.read(0)");
+});
+
+// ───────────────────────── bare state read desugaring ───────────────────────
+
+test("a bare state read in a value position lowers to .read(); a write stays explicit", () => {
+  const c = code(
+    mono(
+      "const env = state.f32(0).named();",
+      `out.ch(0)[i] = max(env, 0.5); env.write(env * 0.99);`,
+    ),
+  );
+  expect(c).toContain("max(env.read(), 0.5)"); // call-arg value position reads
+  expect(c).toContain("env.write(mul(env.read(), 0.99))"); // operand reads; the write target stays
+});
+
+test("$prev is left verbatim (it is an ambient Node, not rewritten by the IDE layer)", () => {
+  const src = `const onepole = defineSubgraph((coef: Node<"f32">) => ({
+  process: (x: Node<"f32">) => coef * x + (1 - coef) * $prev,
+}));
+const input = audioInput({ channels: 1, name: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => { forSample((i) => { out.ch(0)[i] = input.ch(0)[i]; }); });`;
+  const c = code(src);
+  expect(c).toContain("$prev");
+  // the user's explicit parens around `(1 - coef)` are preserved verbatim
+  expect(c).toContain("add(mul(coef, x), mul((sub(1, coef)), $prev))");
+});
+
+// ───────────────────────── auto-name (S9) for type-checking ─────────────────
+
+test("no-arg .named() is filled with the binding name", () => {
+  expect(code(mono("const env = state.f32(0).named();", `out.ch(0)[i] = env;`))).toContain(
+    'state.f32(0).named("env")',
+  );
+});
+
+test("an event with no name gets one injected into its options", () => {
+  const c = code(`const taps = event({ from: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => { taps.onReceive(() => {}); forSample((i) => { out.ch(0)[i] = 0; }); });`);
+  expect(c).toContain('event({ name: "taps", from: "main" })');
+});
+
+test("event.midi with no options object gets a name object injected", () => {
+  const c = code(`const m = event.midi();
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => { forSample((i) => { out.ch(0)[i] = 0; }); });`);
+  expect(c).toContain('event.midi({ name: "m" })');
+});
+
+test("an explicit name is never overwritten by auto-name", () => {
+  const c = code(
+    mono(
+      `const g = param.f32({ default: 1, min: 0, max: 4, automationRate: "a-rate" }).named("custom");`,
+      `out.ch(0)[i] = g[i];`,
+    ),
+  );
+  expect(c).toContain('.named("custom")');
+  expect(c).not.toContain('.named("custom").named');
+});
+
+// ───────────────────────── build-time (non-DSL) pass-through ────────────────
+
+test("a build-time ternary and a prefix-minus on a literal stay as JavaScript", () => {
+  // `48000 > 0` is number-vs-number (the forSample index `i` IS a Node, so a
+  // comparison against it WOULD lower — a build-time condition must use plain numbers).
+  const c = code(mono("", `const k = 48000 > 0 ? 1 : 2; out.ch(0)[i] = input.ch(0)[i] * -2 * k;`));
+  expect(c).toContain("48000 > 0 ? 1 : 2"); // number condition → not a select
+  expect(c).toContain("mul(mul(input.ch(0).at(i), -2), k)"); // dsp multiply lowers; -2 literal stays
+});
+
+test("a plain (non-buffer/non-output) array element write is left verbatim", () => {
+  const c = code(mono("const arr = [0, 0, 0];", `arr[0] = i;`));
+  expect(c).toContain("arr[0] = i;");
+  expect(c).not.toContain("arr.write");
+  expect(c).not.toContain("arr.at");
+});
+
+test("declaration shapes auto-name skips (multi-declarator, destructure, no-init) pass through", () => {
+  const src = `const A = 1, B = 2;
+const [first] = [10, 20];
+let later;
+const input = audioInput({ channels: 1, name: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => { forSample((i) => { out.ch(0)[i] = input.ch(0)[i] * A; }); });`;
+  const c = code(src);
+  expect(c).toContain("const A = 1, B = 2;");
+  expect(c).toContain("const [first] = [10, 20];");
+  expect(c).toContain("let later;");
+  expect(c).toContain("mul(input.ch(0).at(i), A)");
+});
+
+// ───────────────────────── module wrapping ──────────────────────────────────
+
+test("the virtual module shadows the Node `process` global and is a module", () => {
+  const c = code(mono("", `out.ch(0)[i] = input.ch(0)[i];`));
+  expect(c.startsWith("declare function process(callback: () => void): void;\n")).toBe(true);
+  expect(c.trimEnd().endsWith("export {};")).toBe(true);
+});
+
+// ───────────────────────── mapping invariants ───────────────────────────────
+
+test("every verbatim mapping reproduces the author source byte-for-byte", () => {
+  const src = mono(
+    "const env = state.f32(0).named();",
+    `out.ch(0)[i] = input.ch(0)[i] * 2 + env; env.write(env * 0.99);`,
+  );
+  const result = gen(src);
+  for (const m of result.mappings) {
+    if (isSynth(m)) {
+      // injected glue: a zero-width source anchor with its own generated length
+      expect(m.lengths[0]).toBe(0);
+      expect(m.generatedLengths?.[0]).toBeGreaterThan(0);
+      continue;
+    }
+    const srcText = src.slice(m.sourceOffsets[0]!, m.sourceOffsets[0]! + m.lengths[0]!);
+    const genText = result.code.slice(
+      m.generatedOffsets[0]!,
+      m.generatedOffsets[0]! + m.lengths[0]!,
+    );
+    expect(genText).toBe(srcText);
+  }
+});
+
+test("generated offsets are non-decreasing (a valid forward source map)", () => {
+  const result = gen(mono("", `out.ch(0)[i] = input.ch(0)[i] * 2;`));
+  let last = -1;
+  for (const m of result.mappings) {
+    expect(m.generatedOffsets[0]!).toBeGreaterThanOrEqual(last);
+    last = m.generatedOffsets[0]!;
+  }
+});
+
+test("a source identifier maps to the same identifier text in the generated code", () => {
+  const src = mono(
+    'const gain = param.f32({ default: 1, min: 0, max: 4, automationRate: "a-rate" });',
+    `out.ch(0)[i] = input.ch(0)[i] * gain[i];`,
+  );
+  const result = gen(src);
+  // the `gain` use inside the body (the last occurrence) must map to `gain` in the output
+  const useOffset = src.lastIndexOf("gain[i]");
+  const g = toGenerated(result, useOffset);
+  expect(g).toBeGreaterThanOrEqual(0);
+  expect(result.code.startsWith("gain", g)).toBe(true);
+});
+
+test("comments and whitespace between tokens are preserved verbatim", () => {
+  const src = mono("", `// keep me\n    out.ch(0)[i] = input.ch(0)[i]; // trailing`);
+  const c = code(src);
+  expect(c).toContain("// keep me");
+  expect(c).toContain("// trailing");
+});

--- a/packages/lang/src/ide/virtualCode.test.ts
+++ b/packages/lang/src/ide/virtualCode.test.ts
@@ -196,6 +196,14 @@ test("an explicit name is never overwritten by auto-name", () => {
   expect(c).not.toContain('.named("custom").named');
 });
 
+test("an explicit name on an event — even quoted — is not duplicated", () => {
+  const c = code(`const taps = event({ "name": "explicit", from: "main" });
+const out = audioOutput({ channels: 1, name: "main" });
+process(() => { taps.onReceive(() => {}); forSample((i) => { out.ch(0)[i] = 0; }); });`);
+  expect(c).toContain('event({ "name": "explicit", from: "main" })');
+  expect(c).not.toContain('name: "taps"');
+});
+
 // ───────────────────────── build-time (non-DSL) pass-through ────────────────
 
 test("a build-time ternary and a prefix-minus on a literal stay as JavaScript", () => {

--- a/packages/lang/src/ide/virtualCode.test.ts
+++ b/packages/lang/src/ide/virtualCode.test.ts
@@ -183,6 +183,51 @@ test("$prev outside any defineSubgraph method is left verbatim (no slot to type 
   expect(c).not.toContain("as Node<");
 });
 
+test("a defineSubgraph whose factory is a named reference is scanned without crashing", () => {
+  // The factory arrow lives in a separate binding, so the $prev scalar scan finds no
+  // inline arrow to walk — it must pass through (the operator sugar still lowers).
+  const c = code(`const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const factory = (k: Node<"f32">) => ({ run: (x: Node<"f32">) => k * x });
+const sg = defineSubgraph(factory);
+const s = createSubgraph(sg, f32(0.5), { name: "s" });
+process(() => { forSample((i) => { out.ch(0)[i] = s.run(input.ch(0)[i]); }); });`);
+  expect(c).toContain("defineSubgraph(factory)");
+});
+
+test("a subgraph method object with non-$prev / non-arrow properties is scanned cleanly", () => {
+  // The returned object mixes a value property (`gain`) and a method that does NOT
+  // use $prev — neither is a feedback site, so the scan skips both and only the
+  // operator sugar inside the method lowers.
+  const c = code(`const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const sg = defineSubgraph((k: Node<"f32">) => ({
+  gain: k,
+  run: (x: Node<"f32">) => k * x,
+}));
+const s = createSubgraph(sg, f32(0.5), { name: "s" });
+process(() => { forSample((i) => { out.ch(0)[i] = s.run(input.ch(0)[i]); }); });`);
+  expect(c).toContain("mul(k, x)");
+});
+
+test("a $prev method containing a NESTED defineSubgraph types only its own $prev", () => {
+  // `markOwnedPrev` must stop at the nested `defineSubgraph` — the inner method's
+  // `$prev` belongs to the inner method, not the outer one. The outer `$prev` is cast
+  // to the outer slot scalar; the scan walks past the nested subgraph without error.
+  const c = code(`const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const sg = defineSubgraph((k: Node<"f32">) => ({
+  run: (x: Node<"f32">) => {
+    const inner = defineSubgraph(() => ({ step: (y: Node<"f32">) => y + $prev }));
+    return x + $prev * k;
+  },
+}));
+const s = createSubgraph(sg, f32(0.5), { name: "s" });
+process(() => { forSample((i) => { out.ch(0)[i] = s.run(input.ch(0)[i]); }); });`);
+  expect(c).toContain('as Node<"f32">');
+  expect(c).toContain("defineSubgraph");
+});
+
 // ───────────────────────── guarded emit (if-sugar shape 3) ──────────────────
 
 test("a guarded emit rewrites `.emit(` to `.emitIf(true, ` (payload kept, desugared)", () => {
@@ -208,6 +253,20 @@ test("a bare `.emit(` outside a DSP-guarded if is left verbatim", () => {
     ),
   );
   expect(c).toContain("ev.emit({");
+  expect(c).not.toContain("emitIf");
+});
+
+test("an `.emit(` that is NOT a bare statement (used as a value) is left verbatim", () => {
+  // Inside a DSP-guarded `if`, but the emit result is consumed (assigned), so its
+  // parent is not an expression statement — the guarded-emit rewrite must not fire.
+  const c = code(`const out = audioOutput({ channels: 1, name: "main" });
+const input = audioInput({ channels: 1, name: "main" });
+const ev = event<{ level: number }>({ to: "main", name: "ev" });
+const sink = state.f32(0).named("sink");
+process(() => { forSample((i) => {
+  if (input.ch(0)[i] > 0) sink.write(f32(ev.emit({ atSample: i, level: f32(1) })));
+}); });`);
+  expect(c).toContain("ev.emit(");
   expect(c).not.toContain("emitIf");
 });
 

--- a/packages/lang/src/ide/virtualCode.ts
+++ b/packages/lang/src/ide/virtualCode.ts
@@ -175,8 +175,9 @@ function isGuardedEmit(checker: ts.TypeChecker, call: ts.CallExpression): boolea
   const container = stmt.parent;
   const inBlock = ts.isBlock(container);
   const ifStmt = inBlock ? container.parent : container;
+  // With no else, the statement under the `if` is always its then-branch, so a
+  // guarded emit only has to confirm the enclosing `if` has no else and is DSP.
   if (!ts.isIfStatement(ifStmt) || ifStmt.elseStatement !== undefined) return false;
-  if (ifStmt.thenStatement !== (inBlock ? container : stmt)) return false;
   return isDspExpr(checker, ifStmt.expression);
 }
 

--- a/packages/lang/src/ide/virtualCode.ts
+++ b/packages/lang/src/ide/virtualCode.ts
@@ -35,6 +35,7 @@ import { argIsInjectable, calledMethod, optionsHaveName, rootCallee } from "../p
 import { classify, isDspExpr, isSugarBinaryOperator } from "../classify.ts";
 import { readsAsBareState } from "../passes/bareState.ts";
 import { BINARY_FN, NEGATED_EQ } from "../passes/operators.ts";
+import { prevSlotScalars } from "../passes/prev.ts";
 import { buildProgram, type FsSnapshot } from "../program.ts";
 
 /** Author-written code: every language feature maps through 1:1. */
@@ -173,6 +174,9 @@ export function generateVirtualCode(
   const b = new Builder();
   b.raw(MODULE_PREFIX);
   let cursor = 0;
+
+  // `$prev` sites (by source offset) → the slot scalar the lowering would assign.
+  const prevScalars = prevSlotScalars(checker, sourceFile);
 
   const insertions = autoNameInsertions(sourceFile);
   let nextInsertion = 0;
@@ -313,6 +317,22 @@ export function generateVirtualCode(
       b.synth(")", node.getEnd());
       cursor = node.getEnd();
       return true;
+    }
+
+    // `$prev` inside a defineSubgraph method: the lowering rewrites it to a typed
+    // slot read (`state.<scalar>(0).read()` → Node<scalar>). Cast it to that same
+    // scalar so the editor type-checks the concrete type the build assigns, not the
+    // broad ambient `Node<ScalarType>` (which draws bogus errors on valid feedback).
+    // `$prev` itself stays author text, so hover / navigation land on the real token.
+    if (ts.isIdentifier(node) && node.text === "$prev") {
+      const scalar = prevScalars.get(node.getStart(sourceFile));
+      if (scalar !== undefined) {
+        flushTo(node.getStart(sourceFile));
+        b.synth("(", node.getStart(sourceFile));
+        flushTo(node.getEnd());
+        b.synth(` as Node<"${scalar}">)`, node.getEnd());
+        return true;
+      }
     }
 
     // Bare `state` read: `gain` → `gain.read()` (value positions only).

--- a/packages/lang/src/ide/virtualCode.ts
+++ b/packages/lang/src/ide/virtualCode.ts
@@ -162,6 +162,25 @@ function autoNameInsertions(sourceFile: ts.SourceFile): Insertion[] {
 }
 
 /**
+ * A `port.emit(payload)` call that sits as a statement in the then-branch of a
+ * DSP-guarded `if` with no else — exactly the shape {@link tryIfSugar} rewrites to
+ * `port.emitIf(cond, payload)`. The worklet `EventDecl` exposes only `emitIf`, so a
+ * verbatim `emit` would draw a bogus "Property 'emit' does not exist". `emit` appears
+ * only in this guarded shape in a `.uwk.ts`, so matching it is enough to scope the
+ * rewrite to genuine if-sugar.
+ */
+function isGuardedEmit(checker: ts.TypeChecker, call: ts.CallExpression): boolean {
+  const stmt = call.parent;
+  if (!ts.isExpressionStatement(stmt)) return false;
+  const container = stmt.parent;
+  const inBlock = ts.isBlock(container);
+  const ifStmt = inBlock ? container.parent : container;
+  if (!ts.isIfStatement(ifStmt) || ifStmt.elseStatement !== undefined) return false;
+  if (ifStmt.thenStatement !== (inBlock ? container : stmt)) return false;
+  return isDspExpr(checker, ifStmt.expression);
+}
+
+/**
  * Lower a `.uwk.ts` source string to the virtual TypeScript the editor type-checks,
  * plus the source↔generated mappings Volar maps positions through.
  */
@@ -217,6 +236,30 @@ export function generateVirtualCode(
   /** Try to emit `node` as a sugar rewrite; return false if it is not sugar. The
    * cursor is left at `node.getEnd()` on success. */
   const tryEmitSugar = (node: ts.Node): boolean => {
+    // Guarded emit: `port.emit(payload)` inside a DSP-guarded `if` (no else) lowers
+    // to `port.emitIf(cond, payload)`; the worklet EventDecl exposes only `emitIf`,
+    // so a verbatim `emit` is a bogus "Property 'emit' does not exist". Rewrite the
+    // method to `emitIf` with a `true` guard — the real guard stays the surrounding
+    // `if`, and a literal `true` satisfies emitIf's `Node<"bool"> | boolean` first
+    // param, so the payload type-checks exactly as the build checks it.
+    if (
+      ts.isCallExpression(node) &&
+      ts.isPropertyAccessExpression(node.expression) &&
+      node.expression.name.text === "emit" &&
+      node.arguments.length === 1 &&
+      isGuardedEmit(checker, node)
+    ) {
+      const access = node.expression;
+      flushTo(node.getStart(sourceFile));
+      operandObject(access.expression);
+      b.synth(".emitIf(true, ", access.name.getStart(sourceFile));
+      cursor = node.arguments[0]!.getStart(sourceFile);
+      operandObject(node.arguments[0]!);
+      b.synth(")", node.getEnd());
+      cursor = node.getEnd();
+      return true;
+    }
+
     // Binary operator: `L op R` → `add(L, R)` / `not(eq(L, R))` (DSP operands only).
     if (ts.isBinaryExpression(node) && isSugarBinaryOperator(node.operatorToken.kind)) {
       if (!isDspExpr(checker, node.left) && !isDspExpr(checker, node.right)) return false;

--- a/packages/lang/src/ide/virtualCode.ts
+++ b/packages/lang/src/ide/virtualCode.ts
@@ -1,0 +1,338 @@
+/**
+ * IDE virtual-code generator (RFC-001 "Volar.js / TS LSP integration").
+ *
+ * A `.uwk.ts` file is sugar that stock TypeScript rejects (`a * b` on two
+ * `Node<T>` is an "operator cannot be applied" error), which is why authoring it
+ * needs a `// @ts-nocheck` header. This generator produces the *virtual* TypeScript
+ * the editor should type-check instead: the same file with only the sugar
+ * expressions desugared to the chain primitives they lower to (`a * b` →
+ * `mul(a, b)`, `out.left[i] = v` → `out.left.at(i).write(v)`, a bare `state` read →
+ * `state.read()`), everything else byte-for-byte verbatim.
+ *
+ * Unlike {@link lower}, the output is NOT wrapped in `defineProcessor` and injects
+ * no import: the file keeps its ambient shape (`process(() => {...})`, module-level
+ * declarations) and resolves `audioInput` / `state` / `process` / `input` / `out` /
+ * `$prev` against the shipped ambient `.d.ts` (the same `AMBIENT_DTS` the lowering's
+ * type queries use). The editor only needs the source to *type-check* and to map
+ * positions back — it does not need a runnable module.
+ *
+ * Every generated character carries a Volar {@link CodeMapping}:
+ *  - text the author wrote maps 1:1 to its source offset with all features on, so
+ *    hover / completion / go-to-def / rename / diagnostics land on the real token;
+ *  - injected text (`mul(`, `.read()`, `).write(`, …) maps to a zero-width source
+ *    anchor with verification only, so a diagnostic that spans into it still
+ *    projects back to source, but it is invisible to hover / navigation.
+ *
+ * The desugar dispatch reuses the EXACT predicates the lowering passes use
+ * (`classify` / `isDspExpr` / `readsAsBareState`), so the editor rewrites precisely
+ * the identifiers and operators the build does — the two never diverge.
+ */
+
+import type { CodeInformation, CodeMapping } from "@volar/language-core";
+import ts from "typescript";
+
+import { argIsInjectable, calledMethod, optionsHaveName, rootCallee } from "../passes/autoName.ts";
+import { classify, isDspExpr, isSugarBinaryOperator } from "../classify.ts";
+import { readsAsBareState } from "../passes/bareState.ts";
+import { BINARY_FN, NEGATED_EQ } from "../passes/operators.ts";
+import { buildProgram, type FsSnapshot } from "../program.ts";
+
+/** Author-written code: every language feature maps through 1:1. */
+const FULL: CodeInformation = {
+  verification: true,
+  completion: true,
+  semantic: true,
+  navigation: true,
+  structure: true,
+};
+
+/** Injected desugar text: diagnostics project back, but hover / navigation do not. */
+const SYNTH: CodeInformation = { verification: true };
+
+/**
+ * Prepended to the virtual module. `export {}` (appended) makes the file a module
+ * so this local `process` shadows BOTH the ambient `declare global` macro and
+ * `@types/node`'s `var process: Process` (which would otherwise win and report
+ * "Type 'Process' has no call signatures" on every `process(() => {...})`). The
+ * other ambient names need no shadow — they collide with nothing in lib / node.
+ */
+const MODULE_PREFIX = "declare function process(callback: () => void): void;\n";
+const MODULE_SUFFIX = "\nexport {};\n";
+
+/** A name string the auto-name pass would inject, materialised as source text. */
+type Insertion = { offset: number; text: string };
+
+export type VirtualCodeResult = { code: string; mappings: CodeMapping[] };
+
+export type GenerateOptions = {
+  /** Replay a captured file-system snapshot (browser, no disk). */
+  snapshot?: FsSnapshot;
+};
+
+/**
+ * A generated-text accumulator that records a {@link CodeMapping} for every chunk.
+ * `verbatim` copies author source 1:1; `synth` emits desugar glue anchored to a
+ * zero-width source point so diagnostics still project back.
+ */
+class Builder {
+  private readonly parts: string[] = [];
+  private length = 0;
+  readonly mappings: CodeMapping[] = [];
+
+  verbatim(text: string, sourceOffset: number, data: CodeInformation = FULL): void {
+    this.mappings.push({
+      sourceOffsets: [sourceOffset],
+      generatedOffsets: [this.length],
+      lengths: [text.length],
+      data,
+    });
+    this.parts.push(text);
+    this.length += text.length;
+  }
+
+  synth(text: string, sourceAnchor: number): void {
+    this.mappings.push({
+      sourceOffsets: [sourceAnchor],
+      generatedOffsets: [this.length],
+      lengths: [0],
+      generatedLengths: [text.length],
+      data: SYNTH,
+    });
+    this.parts.push(text);
+    this.length += text.length;
+  }
+
+  /** Generated-only structural text with no source correspondence (module glue). */
+  raw(text: string): void {
+    this.parts.push(text);
+    this.length += text.length;
+  }
+
+  toString(): string {
+    return this.parts.join("");
+  }
+}
+
+/**
+ * The names the auto-name pass (S9) injects, as source-offset insertions. Only the
+ * sites where the un-named form is a *type* error need filling: a no-arg `.named()`
+ * (the core signature requires a name) and an `event` / `event.midi` with no `name`
+ * in its options (`EventOptions.name` is required). `audioInput` / `audioOutput`
+ * names are optional in the ambient, `.expose({})` names are optional in core, and
+ * `param.f32({...})` is a complete `Param` un-named — none of those need a fill.
+ * The injected value is irrelevant to type-checking; the binding name is used so a
+ * hover reads naturally and the virtual matches the lowered build.
+ */
+function autoNameInsertions(sourceFile: ts.SourceFile): Insertion[] {
+  const out: Insertion[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isVariableStatement(stmt)) continue;
+    if (stmt.declarationList.declarations.length !== 1) continue;
+    const decl = stmt.declarationList.declarations[0]!;
+    if (!ts.isIdentifier(decl.name) || decl.initializer === undefined) continue;
+    const name = decl.name.text;
+    const init = decl.initializer;
+
+    // No-arg `.named()` → `.named("name")`.
+    if (
+      ts.isCallExpression(init) &&
+      calledMethod(init) === "named" &&
+      init.arguments.length === 0
+    ) {
+      out.push({ offset: init.getEnd() - 1, text: `"${name}"` });
+      continue;
+    }
+    // `event(...)` / `event.midi(...)` with no `name` in its options.
+    if (
+      rootCallee(init) === "event" &&
+      ts.isCallExpression(init) &&
+      !optionsHaveName(init) &&
+      argIsInjectable(init)
+    ) {
+      const arg = init.arguments[0];
+      if (arg !== undefined && ts.isObjectLiteralExpression(arg)) {
+        out.push({ offset: arg.getStart(sourceFile) + 1, text: ` name: "${name}",` });
+      } else {
+        out.push({ offset: init.getEnd() - 1, text: `{ name: "${name}" }` });
+      }
+    }
+  }
+  return out.sort((a, c) => a.offset - c.offset);
+}
+
+/**
+ * Lower a `.uwk.ts` source string to the virtual TypeScript the editor type-checks,
+ * plus the source↔generated mappings Volar maps positions through.
+ */
+export function generateVirtualCode(
+  source: string,
+  options: GenerateOptions = {},
+): VirtualCodeResult {
+  const { checker, sourceFile } = buildProgram(source, { snapshot: options.snapshot });
+  const text = sourceFile.text;
+  const b = new Builder();
+  b.raw(MODULE_PREFIX);
+  let cursor = 0;
+
+  const insertions = autoNameInsertions(sourceFile);
+  let nextInsertion = 0;
+
+  /** Copy author source verbatim from the cursor up to `pos`, emitting any
+   * auto-name insertion whose anchor falls within the copied range, then advance.
+   * Insertions sit in declaration option-objects / `.named()` parens — never inside
+   * a sugar node — so the cursor always reaches an insertion before it skips past. */
+  const flushTo = (pos: number): void => {
+    while (nextInsertion < insertions.length && insertions[nextInsertion]!.offset <= pos) {
+      const ins = insertions[nextInsertion]!;
+      b.verbatim(text.slice(cursor, ins.offset), cursor);
+      b.synth(ins.text, ins.offset);
+      cursor = ins.offset;
+      nextInsertion += 1;
+    }
+    if (pos > cursor) {
+      b.verbatim(text.slice(cursor, pos), cursor);
+      cursor = pos;
+    }
+  };
+
+  /** Emit `e` as a value: desugar it, then read-wrap a bare `State` (mirrors the
+   * operator / index pass, which read-wrap every operand). */
+  const operandValue = (e: ts.Expression): void => {
+    walk(e);
+    flushTo(e.getEnd());
+    if (classify(checker, e) === "state") b.synth(".read()", e.getEnd());
+  };
+
+  /** Emit the object of an index access (a channel view / param / buffer — never a
+   * bare state, so no read-wrap), desugaring any nested sugar. */
+  const operandObject = (e: ts.Expression): void => {
+    walk(e);
+    flushTo(e.getEnd());
+  };
+
+  /** Try to emit `node` as a sugar rewrite; return false if it is not sugar. The
+   * cursor is left at `node.getEnd()` on success. */
+  const tryEmitSugar = (node: ts.Node): boolean => {
+    // Binary operator: `L op R` → `add(L, R)` / `not(eq(L, R))` (DSP operands only).
+    if (ts.isBinaryExpression(node) && isSugarBinaryOperator(node.operatorToken.kind)) {
+      if (!isDspExpr(checker, node.left) && !isDspExpr(checker, node.right)) return false;
+      flushTo(node.getStart(sourceFile));
+      const negated = NEGATED_EQ.has(node.operatorToken.kind);
+      b.synth(
+        negated ? "not(eq(" : `${BINARY_FN[node.operatorToken.kind]!}(`,
+        node.getStart(sourceFile),
+      );
+      operandValue(node.left);
+      b.synth(", ", node.left.getEnd());
+      cursor = node.right.getStart(sourceFile);
+      operandValue(node.right);
+      b.synth(negated ? "))" : ")", node.getEnd());
+      cursor = node.getEnd();
+      return true;
+    }
+
+    // Index write: `obj[i] = v` → `obj.at(i).write(v)` / `obj.write(i, v)`.
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.EqualsToken &&
+      ts.isElementAccessExpression(node.left)
+    ) {
+      const el = node.left;
+      const cls = classify(checker, el.expression);
+      if (cls === "outputChannel" || cls === "buffer") {
+        flushTo(node.getStart(sourceFile));
+        operandObject(el.expression);
+        if (cls === "outputChannel") {
+          b.synth(".at(", el.expression.getEnd());
+          cursor = el.argumentExpression.getStart(sourceFile);
+          operandValue(el.argumentExpression);
+          b.synth(").write(", el.argumentExpression.getEnd());
+        } else {
+          b.synth(".write(", el.expression.getEnd());
+          cursor = el.argumentExpression.getStart(sourceFile);
+          operandValue(el.argumentExpression);
+          b.synth(", ", el.argumentExpression.getEnd());
+        }
+        cursor = node.right.getStart(sourceFile);
+        operandValue(node.right);
+        b.synth(")", node.getEnd());
+        cursor = node.getEnd();
+        return true;
+      }
+    }
+
+    // Index read: `obj[i]` → `obj.at(i)` (input channel / param) / `obj.read(i)`
+    // (buffer). An output channel has no read form (write-only), so it is left
+    // verbatim and correctly errors — matching the lowering's index pass.
+    if (ts.isElementAccessExpression(node)) {
+      const cls = classify(checker, node.expression);
+      const method =
+        cls === "inputChannel" || cls === "param" ? "at" : cls === "buffer" ? "read" : undefined;
+      if (method !== undefined) {
+        flushTo(node.getStart(sourceFile));
+        operandObject(node.expression);
+        b.synth(`.${method}(`, node.expression.getEnd());
+        cursor = node.argumentExpression.getStart(sourceFile);
+        operandValue(node.argumentExpression);
+        b.synth(")", node.getEnd());
+        cursor = node.getEnd();
+        return true;
+      }
+    }
+
+    // Prefix `-x` / `!x` → `neg(x)` / `not(x)` (DSP operand only).
+    if (
+      ts.isPrefixUnaryExpression(node) &&
+      (node.operator === ts.SyntaxKind.MinusToken ||
+        node.operator === ts.SyntaxKind.ExclamationToken) &&
+      isDspExpr(checker, node.operand)
+    ) {
+      flushTo(node.getStart(sourceFile));
+      b.synth(
+        node.operator === ts.SyntaxKind.MinusToken ? "neg(" : "not(",
+        node.getStart(sourceFile),
+      );
+      cursor = node.operand.getStart(sourceFile);
+      operandValue(node.operand);
+      b.synth(")", node.getEnd());
+      cursor = node.getEnd();
+      return true;
+    }
+
+    // Ternary `c ? t : e` → `select(c, t, e)` (DSP condition only).
+    if (ts.isConditionalExpression(node) && isDspExpr(checker, node.condition)) {
+      flushTo(node.getStart(sourceFile));
+      b.synth("select(", node.getStart(sourceFile));
+      operandValue(node.condition);
+      b.synth(", ", node.condition.getEnd());
+      cursor = node.whenTrue.getStart(sourceFile);
+      operandValue(node.whenTrue);
+      b.synth(", ", node.whenTrue.getEnd());
+      cursor = node.whenFalse.getStart(sourceFile);
+      operandValue(node.whenFalse);
+      b.synth(")", node.getEnd());
+      cursor = node.getEnd();
+      return true;
+    }
+
+    // Bare `state` read: `gain` → `gain.read()` (value positions only).
+    if (ts.isIdentifier(node) && readsAsBareState(checker, node)) {
+      flushTo(node.getEnd());
+      b.synth(".read()", node.getEnd());
+      return true;
+    }
+
+    return false;
+  };
+
+  function walk(node: ts.Node): void {
+    if (tryEmitSugar(node)) return;
+    ts.forEachChild(node, walk);
+  }
+
+  walk(sourceFile);
+  flushTo(text.length);
+  b.raw(MODULE_SUFFIX);
+
+  return { code: b.toString(), mappings: b.mappings };
+}

--- a/packages/lang/src/ide/virtualCode.ts
+++ b/packages/lang/src/ide/virtualCode.ts
@@ -34,6 +34,7 @@ import ts from "typescript";
 import { argIsInjectable, calledMethod, optionsHaveName, rootCallee } from "../passes/autoName.ts";
 import { classify, isDspExpr, isSugarBinaryOperator } from "../classify.ts";
 import { readsAsBareState } from "../passes/bareState.ts";
+import { detectEmits } from "../passes/ifSugar.ts";
 import { BINARY_FN, NEGATED_EQ } from "../passes/operators.ts";
 import { prevSlotScalars } from "../passes/prev.ts";
 import { buildProgram, type FsSnapshot } from "../program.ts";
@@ -162,12 +163,16 @@ function autoNameInsertions(sourceFile: ts.SourceFile): Insertion[] {
 }
 
 /**
- * A `port.emit(payload)` call that sits as a statement in the then-branch of a
- * DSP-guarded `if` with no else — exactly the shape {@link tryIfSugar} rewrites to
- * `port.emitIf(cond, payload)`. The worklet `EventDecl` exposes only `emitIf`, so a
- * verbatim `emit` would draw a bogus "Property 'emit' does not exist". `emit` appears
- * only in this guarded shape in a `.uwk.ts`, so matching it is enough to scope the
- * rewrite to genuine if-sugar.
+ * A `port.emit(payload)` call that sits in the then-branch of a DSP-guarded `if`
+ * with no else, where EVERY statement of that branch is an emit — exactly the shape
+ * {@link tryIfSugar} rewrites to `port.emitIf(cond, payload)`. The worklet `EventDecl`
+ * exposes only `emitIf`, so a verbatim `emit` would draw a bogus "Property 'emit'
+ * does not exist".
+ *
+ * The all-emits gate (`detectEmits`, the build's own check) is load-bearing: a branch
+ * mixing an emit with any other statement is rejected by the build
+ * (`uwk-unsupported-if`), so the editor must leave `emit` unrewritten there too —
+ * otherwise it would green-light a `.uwk.ts` the build refuses to compile.
  */
 function isGuardedEmit(checker: ts.TypeChecker, call: ts.CallExpression): boolean {
   const stmt = call.parent;
@@ -175,10 +180,10 @@ function isGuardedEmit(checker: ts.TypeChecker, call: ts.CallExpression): boolea
   const container = stmt.parent;
   const inBlock = ts.isBlock(container);
   const ifStmt = inBlock ? container.parent : container;
-  // With no else, the statement under the `if` is always its then-branch, so a
-  // guarded emit only has to confirm the enclosing `if` has no else and is DSP.
+  // With no else, the statement under the `if` is always its then-branch.
   if (!ts.isIfStatement(ifStmt) || ifStmt.elseStatement !== undefined) return false;
-  return isDspExpr(checker, ifStmt.expression);
+  if (!isDspExpr(checker, ifStmt.expression)) return false;
+  return detectEmits(ifStmt.thenStatement) !== undefined;
 }
 
 /**

--- a/packages/lang/src/index.ts
+++ b/packages/lang/src/index.ts
@@ -8,3 +8,11 @@ export { lower, LowerError } from "./lower.ts";
 export type { LowerOptions } from "./lower.ts";
 export { captureFsSnapshot } from "./capture.ts";
 export type { FsSnapshot } from "./program.ts";
+
+// IDE / editor tooling (RFC-001 "Volar.js / TS LSP integration"): the language
+// plugin + virtual-code generator that make `.uwk.ts` sugar type-check in an
+// editor or a headless Volar program proxy.
+export { generateVirtualCode } from "./ide/virtualCode.ts";
+export type { GenerateOptions, VirtualCodeResult } from "./ide/virtualCode.ts";
+export { createUwkLanguagePlugin, isUwkScript, UWK_LANGUAGE_ID } from "./ide/languagePlugin.ts";
+export type { UwkLanguagePluginOptions } from "./ide/languagePlugin.ts";

--- a/packages/lang/src/lower.test.ts
+++ b/packages/lang/src/lower.test.ts
@@ -159,6 +159,38 @@ test("rejects migrations() referencing a DESTRUCTURED top-level binding", () => 
   }
 });
 
+test("rejects options() referencing a moved CLASS declaration", () => {
+  // A class declaration is moved into the callback like a const / function binding,
+  // so referencing it from the (outside-the-callback) options arg is out of scope.
+  try {
+    lower(`class Tag {}\noptions({ tag: Tag });\nprocess(() => {});`);
+    throw new Error("expected throw");
+  } catch (e) {
+    expect((e as LowerError).id).toBe("uwk-options-binding");
+  }
+});
+
+test("rejects migrations() referencing an ARRAY-DESTRUCTURED binding (with a hole)", () => {
+  // Array destructuring with a hole (`[, second]`) exercises the omitted-element
+  // path of the binding-name scan; the named element is still collected, so a
+  // migrations() reference to it is caught as out of scope.
+  try {
+    lower(
+      `const [, second] = pair;\nmigrations([{ to: 1, migrate: second }]);\nprocess(() => {});`,
+    );
+    throw new Error("expected throw");
+  } catch (e) {
+    expect((e as LowerError).id).toBe("uwk-options-binding");
+  }
+});
+
+test("a top-level class declaration is moved into the processor body untouched", () => {
+  // A class that is NOT referenced from options()/migrations() is a valid body
+  // declaration and survives verbatim inside the defineProcessor callback.
+  const lowered = lower(`class Helper {}\nprocess(() => {});`);
+  expect(lowered).toContain("class Helper");
+});
+
 test("rejects a process() with no callback argument", () => {
   try {
     lower(`process();`);

--- a/packages/lang/src/passes/autoName.ts
+++ b/packages/lang/src/passes/autoName.ts
@@ -22,7 +22,7 @@ import ts from "typescript";
 const f = ts.factory;
 
 /** The leftmost identifier of a call/property chain (the root helper name). */
-function rootCallee(expr: ts.Expression): string | undefined {
+export function rootCallee(expr: ts.Expression): string | undefined {
   let e: ts.Expression = expr;
   for (;;) {
     if (ts.isCallExpression(e)) {
@@ -55,12 +55,12 @@ function hasMethodCall(expr: ts.Expression, method: string): boolean {
 }
 
 /** The method name of a call whose callee is `obj.method(...)`, else undefined. */
-function calledMethod(call: ts.CallExpression): string | undefined {
+export function calledMethod(call: ts.CallExpression): string | undefined {
   return ts.isPropertyAccessExpression(call.expression) ? call.expression.name.text : undefined;
 }
 
 /** Whether the call's first-arg options object already has a `name` property. */
-function optionsHaveName(call: ts.CallExpression): boolean {
+export function optionsHaveName(call: ts.CallExpression): boolean {
   const arg = call.arguments[0];
   if (arg === undefined || !ts.isObjectLiteralExpression(arg)) return false;
   // The key may be written either bare (`name:`) or quoted (`"name":`) — a quoted
@@ -75,7 +75,7 @@ function optionsHaveName(call: ts.CallExpression): boolean {
 }
 
 /** Whether the call's first argument can carry an injected `name` (object or absent). */
-function argIsInjectable(call: ts.CallExpression): boolean {
+export function argIsInjectable(call: ts.CallExpression): boolean {
   const arg = call.arguments[0];
   return arg === undefined || ts.isObjectLiteralExpression(arg);
 }

--- a/packages/lang/src/passes/bareState.ts
+++ b/packages/lang/src/passes/bareState.ts
@@ -59,26 +59,35 @@ function read(node: ts.Expression): ts.CallExpression {
   );
 }
 
-export function tryBareState(checker: ts.TypeChecker, node: ts.Node): ts.Node | undefined {
-  if (!ts.isIdentifier(node)) return undefined;
-  if (classify(checker, node) !== "state") return undefined;
+/**
+ * Whether a bare `State<T>` identifier reads (`gain` → `gain.read()`) at this
+ * position. The single source of truth for the bare-state decision, shared by the
+ * lowering pass ({@link tryBareState}) and the IDE virtual-code generator — both
+ * must rewrite the exact same identifiers, or the editor would diverge from the
+ * build.
+ */
+export function readsAsBareState(checker: ts.TypeChecker, node: ts.Node): boolean {
+  if (!ts.isIdentifier(node)) return false;
+  if (classify(checker, node) !== "state") return false;
 
   const p = node.parent;
   // Object of a property access (`gain.read` / `.write` / `.named` / `.expose`) — the handle.
-  if (p !== undefined && ts.isPropertyAccessExpression(p) && p.expression === node)
-    return undefined;
+  if (p !== undefined && ts.isPropertyAccessExpression(p) && p.expression === node) return false;
   // The binding being declared.
-  if (p !== undefined && ts.isVariableDeclaration(p) && p.name === node) return undefined;
+  if (p !== undefined && ts.isVariableDeclaration(p) && p.name === node) return false;
   // Operator operands are read-wrapped by the operator pass.
-  if (isSugarOperatorOperand(checker, node)) return undefined;
+  if (isSugarOperatorOperand(checker, node)) return false;
 
   // An emit payload field accepts Node | number at runtime even though its TS
   // field type prints `number`, so a bare State there must read.
-  if (isEmitPayloadField(node)) return read(node);
+  if (isEmitPayloadField(node)) return true;
 
   // Otherwise only a position whose contextual type accepts a Node is a value position.
   const ctx = checker.getContextualType(node);
-  if (ctx === undefined) return undefined;
-  if (!checker.typeToString(ctx).includes("Node<")) return undefined;
-  return read(node);
+  if (ctx === undefined) return false;
+  return checker.typeToString(ctx).includes("Node<");
+}
+
+export function tryBareState(checker: ts.TypeChecker, node: ts.Node): ts.Node | undefined {
+  return readsAsBareState(checker, node) ? read(node as ts.Expression) : undefined;
 }

--- a/packages/lang/src/passes/bareState.ts
+++ b/packages/lang/src/passes/bareState.ts
@@ -19,6 +19,9 @@ import { classify, isDspExpr, isSugarBinaryOperator } from "../classify.ts";
  * JS-boolean ternary is NOT lowered, so its branches are NOT operator operands. */
 function isSugarOperatorOperand(checker: ts.TypeChecker, node: ts.Node): boolean {
   const p = node.parent;
+  // Every expression node in a parsed tree has a parent (only the SourceFile root
+  // does not, and that is never an operand) — a defensive guard, never taken.
+  /* v8 ignore next */
   if (p === undefined) return false;
   if (ts.isBinaryExpression(p) && isSugarBinaryOperator(p.operatorToken.kind)) {
     return p.left === node || p.right === node;
@@ -41,6 +44,9 @@ function isEmitPayloadField(node: ts.Node): boolean {
   if (prop === undefined || !ts.isPropertyAssignment(prop) || prop.initializer !== node)
     return false;
   const obj = prop.parent;
+  // A PropertyAssignment in a parsed tree always sits inside an ObjectLiteral, so
+  // `obj` is never undefined here — the `=== undefined` arm is a defensive guard.
+  /* v8 ignore next */
   if (obj === undefined || !ts.isObjectLiteralExpression(obj)) return false;
   const call = obj.parent;
   return (

--- a/packages/lang/src/passes/ifSugar.ts
+++ b/packages/lang/src/passes/ifSugar.ts
@@ -102,8 +102,11 @@ function sameTarget(a: Write, b: Write): boolean {
   return false;
 }
 
-/** A block whose statements are all `port.emit(payload)` calls. */
-function detectEmits(
+/** A block whose statements are all `port.emit(payload)` calls. Exported so the IDE
+ * virtual-code generator gates its guarded-emit rewrite on the SAME all-emits shape
+ * the build accepts — a then-branch mixing an emit with anything else is rejected by
+ * the build (`uwk-unsupported-if`), so the editor must not rewrite it either. */
+export function detectEmits(
   stmt: ts.Statement,
 ): Array<{ port: ts.Expression; payload: ts.Expression }> | undefined {
   const out: Array<{ port: ts.Expression; payload: ts.Expression }> = [];

--- a/packages/lang/src/passes/ifSugar.ts
+++ b/packages/lang/src/passes/ifSugar.ts
@@ -95,10 +95,10 @@ const writeWith = (w: Write, value: ts.Expression): ts.Statement =>
 
 /** Same write target (by source text) — symmetric-if requires it. */
 function sameTarget(a: Write, b: Write): boolean {
-  if (a.kind !== b.kind) return false;
   if (a.kind === "state" && b.kind === "state") return a.target.getText() === b.target.getText();
   if (a.kind === "buffer" && b.kind === "buffer")
     return a.buf.getText() === b.buf.getText() && a.idx.getText() === b.idx.getText();
+  // The kinds differ (a state write vs a buffer write) — not the same target.
   return false;
 }
 

--- a/packages/lang/src/passes/operators.ts
+++ b/packages/lang/src/passes/operators.ts
@@ -19,7 +19,7 @@ import ts from "typescript";
 
 import { classify, isDspExpr, isSugarBinaryOperator } from "../classify.ts";
 
-const BINARY_FN: Partial<Record<ts.SyntaxKind, string>> = {
+export const BINARY_FN: Partial<Record<ts.SyntaxKind, string>> = {
   [ts.SyntaxKind.PlusToken]: "add",
   [ts.SyntaxKind.MinusToken]: "sub",
   [ts.SyntaxKind.AsteriskToken]: "mul",
@@ -32,7 +32,7 @@ const BINARY_FN: Partial<Record<ts.SyntaxKind, string>> = {
   [ts.SyntaxKind.EqualsEqualsToken]: "eq",
   [ts.SyntaxKind.EqualsEqualsEqualsToken]: "eq",
 };
-const NEGATED_EQ = new Set<ts.SyntaxKind>([
+export const NEGATED_EQ = new Set<ts.SyntaxKind>([
   ts.SyntaxKind.ExclamationEqualsToken,
   ts.SyntaxKind.ExclamationEqualsEqualsToken,
 ]);

--- a/packages/lang/src/passes/prev.ts
+++ b/packages/lang/src/passes/prev.ts
@@ -142,6 +142,70 @@ function returnedObject(
   return undefined;
 }
 
+/**
+ * Mark every `$prev` identifier OWNED by this method body (i.e. not inside a nested
+ * `defineSubgraph`, whose `$prev` belongs to that inner method) with `scalar`. This
+ * mirrors the lowering's {@link replacePrev}, which rewrites exactly those `$prev`
+ * to the method's slot after any nested subgraph has already been lowered.
+ */
+function markOwnedPrev(
+  body: ts.Node,
+  scalar: string,
+  sourceFile: ts.SourceFile,
+  out: Map<number, string>,
+): void {
+  const v = (n: ts.Node): void => {
+    if (isDefineSubgraph(n)) return; // a nested subgraph's `$prev` is the inner method's
+    if (ts.isIdentifier(n) && n.text === "$prev") {
+      out.set(n.getStart(sourceFile), scalar);
+      return;
+    }
+    ts.forEachChild(n, v);
+  };
+  v(body);
+}
+
+/**
+ * Map each `$prev` identifier (keyed by its source start offset) to the slot scalar
+ * the lowering would give it — the SAME per-method {@link slotScalar} `tryPrev`
+ * injects. The IDE virtual-code generator uses this to type `$prev` as the concrete
+ * `Node<scalar>` the build lowers it to, instead of the broad ambient
+ * `Node<ScalarType>` that draws bogus editor diagnostics on otherwise-valid feedback.
+ */
+export function prevSlotScalars(
+  checker: ts.TypeChecker,
+  sourceFile: ts.SourceFile,
+): Map<number, string> {
+  const out = new Map<number, string>();
+  const visit = (node: ts.Node): void => {
+    if (isDefineSubgraph(node)) {
+      const arrow = node.arguments[0];
+      if (arrow !== undefined && ts.isArrowFunction(arrow)) {
+        const ret = returnedObject(arrow);
+        if (ret !== undefined) {
+          for (const p of ret.obj.properties) {
+            if (
+              ts.isPropertyAssignment(p) &&
+              ts.isArrowFunction(p.initializer) &&
+              usesPrev(p.initializer)
+            ) {
+              markOwnedPrev(
+                p.initializer.body,
+                slotScalar(checker, p.initializer),
+                sourceFile,
+                out,
+              );
+            }
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(sourceFile);
+  return out;
+}
+
 export function tryPrev(
   checker: ts.TypeChecker,
   node: ts.Node,

--- a/packages/lang/src/program.ts
+++ b/packages/lang/src/program.ts
@@ -21,12 +21,22 @@ import ts from "typescript";
 
 import { AMBIENT_DTS } from "./ambient.ts";
 
-// `import.meta.dirname` is a plain string in Node and `undefined` in the browser
-// — a property read, NOT a `node:url` / `node:path` import (those externalize and
-// crash the browser bundle). In the browser a snapshot is always supplied, so the
-// disk-relative paths below are never resolved against a real file system; they
-// are just stable keys that match the captured snapshot.
-const SELF_DIR = (import.meta as { dirname?: string }).dirname ?? "/__uwk__";
+// The directory the in-memory virtuals are placed under, which disk-backed module
+// resolution (Node) walks up from to find `@unworklet/core`. `import.meta.dirname`
+// is a plain string under Node ESM and `undefined` in the browser — a property
+// read, NOT a `node:url` / `node:path` import (those externalize and crash the
+// browser bundle). The editor TS-plugin is bundled to CJS, where `import.meta` is
+// empty but esbuild supplies `__dirname` (the bundle's dir, which sits in
+// `node_modules/@unworklet/lang/dist`, so core resolves from the same install) —
+// `typeof __dirname` is the one safe way to reach it without a ReferenceError in
+// ESM. In the browser a snapshot is always supplied, so these paths are never
+// resolved against disk; they are just stable keys matching the captured snapshot.
+/* v8 ignore next 3 — environment detection: under the Node ESM test runner
+   `import.meta.dirname` is always set, so the CJS-bundle (`__dirname`, used by the
+   editor TS plugin) and browser (`/__uwk__`) fallbacks are unreachable here. */
+const SELF_DIR =
+  (import.meta as { dirname?: string }).dirname ??
+  (typeof __dirname === "string" ? __dirname : "/__uwk__");
 
 const COMPILER_OPTIONS: ts.CompilerOptions = {
   target: ts.ScriptTarget.ESNext,

--- a/packages/lang/src/program.ts
+++ b/packages/lang/src/program.ts
@@ -147,6 +147,9 @@ function replayHost(source: string, snap: FsSnapshot): ts.CompilerHost {
   return {
     getSourceFile: (fileName, languageVersionOrOptions) => {
       const content = text(fileName);
+      // Every file the checker requests during replay is present in the snapshot
+      // (the captured graph is complete), so the `undefined` arm is defensive.
+      /* v8 ignore next */
       return content === undefined
         ? undefined
         : ts.createSourceFile(fileName, content, languageVersionOrOptions, true, ts.ScriptKind.TS);
@@ -157,11 +160,18 @@ function replayHost(source: string, snap: FsSnapshot): ts.CompilerHost {
       snap.sourceTexts[fileName] !== undefined ||
       snap.fileExists[fileName] === true,
     directoryExists: (dir) => snap.dirExists[dir] === true,
+    // The `?? []` / `?? p` fallbacks only fire for a key the snapshot never recorded;
+    // a complete capture answers every lookup, so they are defensive normalization.
+    /* v8 ignore next 2 */
     getDirectories: (dir) => snap.dirs[dir] ?? [],
     realpath: (p) => snap.realpath[p] ?? p,
     writeFile: () => undefined,
     getDefaultLibFileName: () => snap.defaultLibFileName,
     getCurrentDirectory: () => snap.currentDirectory,
+    // `useCaseSensitiveFileNames` mirrors the recording host; on a case-insensitive
+    // file system only the `toLowerCase()` arm runs, on a case-sensitive one only
+    // the identity arm — one side is always dead for a given recording environment.
+    /* v8 ignore next */
     getCanonicalFileName: (f) => (snap.useCaseSensitiveFileNames ? f : f.toLowerCase()),
     useCaseSensitiveFileNames: () => snap.useCaseSensitiveFileNames,
     getNewLine: () => snap.newLine,
@@ -200,17 +210,26 @@ function diskHost(source: string, record?: FsSnapshot): ts.CompilerHost {
     return sf;
   };
   host.readFile = (fileName) => {
+    // The virtuals are served through `getSourceFile`; the program build never
+    // routes them through `readFile`, so the virtual short-circuit is defensive.
+    /* v8 ignore next */
     if (virtuals[fileName] !== undefined) return virtuals[fileName];
     const content = base.readFile(fileName);
     if (record && content !== undefined) record.sourceTexts[fileName] = content;
     return content;
   };
   host.fileExists = (fileName) => {
+    // Same as `readFile`: resolution checks the virtuals via `getSourceFile`, not
+    // through `fileExists`, so this short-circuit is defensive.
+    /* v8 ignore next */
     if (virtuals[fileName] !== undefined) return true;
     const exists = base.fileExists(fileName);
     if (record) record.fileExists[fileName] = exists;
     return exists;
   };
+  // `ts.createCompilerHost` always supplies these three methods on Node, so the
+  // `false` arm (host lacks the method) is unreachable in this environment.
+  /* v8 ignore next */
   if (base.directoryExists) {
     host.directoryExists = (dir) => {
       const exists = base.directoryExists!(dir);
@@ -218,6 +237,7 @@ function diskHost(source: string, record?: FsSnapshot): ts.CompilerHost {
       return exists;
     };
   }
+  /* v8 ignore next */
   if (base.getDirectories) {
     host.getDirectories = (dir) => {
       const dirs = base.getDirectories!(dir);
@@ -225,6 +245,7 @@ function diskHost(source: string, record?: FsSnapshot): ts.CompilerHost {
       return dirs;
     };
   }
+  /* v8 ignore next */
   if (base.realpath) {
     host.realpath = (p) => {
       const rp = base.realpath!(p);
@@ -240,6 +261,9 @@ function buildFrom(source: string, host: ts.CompilerHost, selfDir: string): Buil
   const program = ts.createProgram([ambientPathFor(selfDir), inputPath], COMPILER_OPTIONS, host);
   const checker = program.getTypeChecker();
   const sourceFile = program.getSourceFile(inputPath);
+  // `inputPath` is one of the two files passed to `createProgram` and the host
+  // always serves it, so the program always contains it — a defensive guard.
+  /* v8 ignore next 3 */
   if (sourceFile === undefined) {
     throw new Error("unworklet/lang: failed to build the .uwk.ts program (input not found)");
   }

--- a/packages/lang/src/typescript-plugin.test.ts
+++ b/packages/lang/src/typescript-plugin.test.ts
@@ -1,0 +1,15 @@
+/**
+ * The editor entry is a well-formed TypeScript-server plugin factory. tsserver
+ * loads the module and calls it with `{ typescript }`; the export must therefore
+ * be a function. (The end-to-end behavior it wires up — diagnostics, hover,
+ * completion, definition over the same language plugin — is proven in
+ * `ide/languagePlugin.test.ts`.)
+ */
+
+import { expect, test } from "vite-plus/test";
+
+import plugin from "./typescript-plugin.ts";
+
+test("the default export is a PluginModuleFactory function tsserver can call", () => {
+  expect(typeof plugin).toBe("function");
+});

--- a/packages/lang/src/typescript-plugin.ts
+++ b/packages/lang/src/typescript-plugin.ts
@@ -1,0 +1,28 @@
+/**
+ * The editor entry point: a TypeScript language-service plugin that makes
+ * `.uwk.ts` files type-check through their desugared virtual code. Add it to a
+ * `tsconfig.json` (alongside the shipped ambient `.d.ts`) to get diagnostics,
+ * hover, completion, rename, and go-to-definition on the sugar — no
+ * `// @ts-nocheck` needed:
+ *
+ * ```jsonc
+ * {
+ *   "compilerOptions": {
+ *     "plugins": [{ "name": "@unworklet/lang/typescript-plugin" }],
+ *     "types": ["@unworklet/lang/ambient"]
+ *   }
+ * }
+ * ```
+ *
+ * VS Code users also select "Use Workspace Version" of TypeScript so the editor
+ * loads the plugin. The same module powers a `tsc`-style CLI via Volar's program
+ * proxy; see {@link createUwkLanguagePlugin}.
+ */
+
+import { createLanguageServicePlugin } from "@volar/typescript/lib/quickstart/createLanguageServicePlugin.js";
+
+import { createUwkLanguagePlugin } from "./ide/languagePlugin.ts";
+
+export default createLanguageServicePlugin((ts) => ({
+  languagePlugins: [createUwkLanguagePlugin(ts)],
+}));

--- a/packages/lang/vite.config.ts
+++ b/packages/lang/vite.config.ts
@@ -18,8 +18,10 @@ export default defineConfig({
   test: {
     include: ["src/**/*.test.ts"],
     // Each lowering builds a fresh in-memory ts.Program; a single test can lower a
-    // dozen sources, so a heavy case brushes the default 5s under parallel load.
-    testTimeout: 30000,
+    // dozen sources, and the snapshot capture/replay case does it many times over.
+    // Under parallel coverage instrumentation that heaviest case runs ~30s, so the
+    // per-test budget is generous.
+    testTimeout: 60000,
     coverage: {
       provider: "v8",
       include: ["src/**/*.ts"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ catalogs:
     '@vitest/coverage-v8':
       specifier: ^4.1.7
       version: 4.1.7
+    '@volar/language-core':
+      specifier: 2.4.15
+      version: 2.4.15
+    '@volar/typescript':
+      specifier: 2.4.15
+      version: 2.4.15
     '@vue-flow/background':
       specifier: ^1.3.2
       version: 1.3.2
@@ -48,6 +54,9 @@ catalogs:
     monaco-editor:
       specifier: ^0.55.1
       version: 0.55.1
+    muggle-string:
+      specifier: 0.4.1
+      version: 0.4.1
     playwright:
       specifier: ^1.60.0
       version: 1.60.0
@@ -128,10 +137,10 @@ importers:
         version: 0.2.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@8.0.14)
       '@vitejs/devtools-kit':
         specifier: 'catalog:'
-        version: 0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.2.0(typescript@5.9.3)(vite@8.0.14)
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
-        version: 6.0.7(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
+        version: 6.0.7(vite@8.0.14)(vue@3.5.34(typescript@5.9.3))
       esbuild:
         specifier: 'catalog:'
         version: 0.28.0
@@ -175,6 +184,15 @@ importers:
       '@unworklet/core':
         specifier: workspace:*
         version: link:../core
+      '@volar/language-core':
+        specifier: 'catalog:'
+        version: 2.4.15
+      '@volar/typescript':
+        specifier: 'catalog:'
+        version: 2.4.15
+      muggle-string:
+        specifier: 'catalog:'
+        version: 0.4.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -196,7 +214,7 @@ importers:
         version: 0.28.0
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.24(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7(vitest@4.1.7))(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.24(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
   packages/offline:
     dependencies:
@@ -286,7 +304,7 @@ importers:
     dependencies:
       '@vitejs/devtools-kit':
         specifier: 'catalog:'
-        version: 0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
+        version: 0.2.0(typescript@5.9.3)(vite@8.0.14)
       '@vue-flow/background':
         specifier: 'catalog:'
         version: 1.3.2(@vue-flow/core@1.48.2(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
@@ -311,7 +329,7 @@ importers:
         version: 24.12.4
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
-        version: 6.0.7(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
+        version: 6.0.7(vite@8.0.14)(vue@3.5.34(typescript@5.9.3))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -3007,7 +3025,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/devtools-kit@0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitejs/devtools-kit@0.2.0(typescript@5.9.3)(vite@8.0.14)':
     dependencies:
       birpc: 4.0.0
       devframe: 0.4.1(typescript@5.9.3)
@@ -3029,7 +3047,7 @@ snapshots:
       '@floating-ui/dom': 1.7.6
       '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
       '@rolldown/debug': 1.0.3
-      '@vitejs/devtools-kit': 0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitejs/devtools-kit': 0.2.0(typescript@5.9.3)(vite@8.0.14)
       birpc: 4.0.0
       cac: 7.0.0
       d3-shape: 3.2.0
@@ -3079,7 +3097,7 @@ snapshots:
 
   '@vitejs/devtools@0.2.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@8.0.14)':
     dependencies:
-      '@vitejs/devtools-kit': 0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitejs/devtools-kit': 0.2.0(typescript@5.9.3)(vite@8.0.14)
       '@vitejs/devtools-rolldown': 0.2.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@8.0.14)(vue@3.5.34(typescript@5.9.3))
       birpc: 4.0.0
       cac: 7.0.0
@@ -3121,7 +3139,7 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.14)(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.14(@types/node@24.12.4)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,24 +6,72 @@ settings:
 
 catalogs:
   default:
+    '@fontsource-variable/geist':
+      specifier: ^5.2.9
+      version: 5.2.9
+    '@fontsource-variable/jetbrains-mono':
+      specifier: ^5.2.8
+      version: 5.2.8
     '@types/node':
       specifier: ^24
       version: 24.12.4
+    '@vitejs/devtools':
+      specifier: 0.2.0
+      version: 0.2.0
+    '@vitejs/devtools-kit':
+      specifier: ^0.2.0
+      version: 0.2.0
+    '@vitejs/plugin-vue':
+      specifier: ^6.0.7
+      version: 6.0.7
+    '@vitest/coverage-v8':
+      specifier: ^4.1.7
+      version: 4.1.7
     '@volar/language-core':
       specifier: 2.4.15
       version: 2.4.15
     '@volar/typescript':
       specifier: 2.4.15
       version: 2.4.15
+    '@vue-flow/background':
+      specifier: ^1.3.2
+      version: 1.3.2
+    '@vue-flow/controls':
+      specifier: ^1.1.3
+      version: 1.1.3
+    '@vue-flow/core':
+      specifier: ^1.48.2
+      version: 1.48.2
+    binaryen:
+      specifier: ^129.0.0
+      version: 129.0.0
     esbuild:
       specifier: ^0.28.0
       version: 0.28.0
+    jszip:
+      specifier: ^3.10.1
+      version: 3.10.1
+    monaco-editor:
+      specifier: ^0.55.1
+      version: 0.55.1
+    playwright:
+      specifier: ^1.60.0
+      version: 1.60.0
     typescript:
       specifier: ^5
       version: 5.9.3
     vite-plus:
       specifier: latest
       version: 0.1.24
+    vue:
+      specifier: ^3.5.34
+      version: 3.5.34
+    vue-router:
+      specifier: ^4.6.4
+      version: 4.6.4
+    wavefile:
+      specifier: ^11.0.0
+      version: 11.0.0
 
 overrides:
   vite: npm:@voidzero-dev/vite-plus-core@latest
@@ -86,10 +134,10 @@ importers:
         version: 0.2.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@8.0.14)
       '@vitejs/devtools-kit':
         specifier: 'catalog:'
-        version: 0.2.0(typescript@5.9.3)(vite@8.0.14)
+        version: 0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
       '@vitejs/plugin-vue':
         specifier: 'catalog:'
-        version: 6.0.7(vite@8.0.14)(vue@3.5.34(typescript@5.9.3))
+        version: 6.0.7(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       esbuild:
         specifier: 'catalog:'
         version: 0.28.0
@@ -160,7 +208,9 @@ importers:
         version: 0.28.0
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.24(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7(vitest@4.1.7))(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+
+  packages/lang/typescript-plugin: {}
 
   packages/offline:
     dependencies:
@@ -250,7 +300,7 @@ importers:
     dependencies:
       '@vitejs/devtools-kit':
         specifier: 'catalog:'
-        version: 0.2.0(typescript@5.9.3)(vite@8.0.14)
+        version: 0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
       '@vue-flow/background':
         specifier: 'catalog:'
         version: 1.3.2(@vue-flow/core@1.48.2(vue@3.5.34(typescript@5.9.3)))(vue@3.5.34(typescript@5.9.3))
@@ -275,7 +325,7 @@ importers:
         version: 24.12.4
       '@vitejs/plugin-vue':
         specifier: ^6.0.0
-        version: 6.0.7(vite@8.0.14)(vue@3.5.34(typescript@5.9.3))
+        version: 6.0.7(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -2971,7 +3021,7 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@vitejs/devtools-kit@0.2.0(typescript@5.9.3)(vite@8.0.14)':
+  '@vitejs/devtools-kit@0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))':
     dependencies:
       birpc: 4.0.0
       devframe: 0.4.1(typescript@5.9.3)
@@ -2993,7 +3043,7 @@ snapshots:
       '@floating-ui/dom': 1.7.6
       '@pnpm/read-project-manifest': 1001.2.6(@pnpm/logger@1001.0.1)
       '@rolldown/debug': 1.0.3
-      '@vitejs/devtools-kit': 0.2.0(typescript@5.9.3)(vite@8.0.14)
+      '@vitejs/devtools-kit': 0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
       birpc: 4.0.0
       cac: 7.0.0
       d3-shape: 3.2.0
@@ -3043,7 +3093,7 @@ snapshots:
 
   '@vitejs/devtools@0.2.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@8.0.14)':
     dependencies:
-      '@vitejs/devtools-kit': 0.2.0(typescript@5.9.3)(vite@8.0.14)
+      '@vitejs/devtools-kit': 0.2.0(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))
       '@vitejs/devtools-rolldown': 0.2.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@8.0.14)(vue@3.5.34(typescript@5.9.3))
       birpc: 4.0.0
       cac: 7.0.0
@@ -3085,7 +3135,7 @@ snapshots:
       - uploadthing
       - utf-8-validate
 
-  '@vitejs/plugin-vue@6.0.7(vite@8.0.14)(vue@3.5.34(typescript@5.9.3))':
+  '@vitejs/plugin-vue@6.0.7(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(vue@3.5.34(typescript@5.9.3))':
     dependencies:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.0.14(@types/node@24.12.4)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0)
@@ -3159,20 +3209,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.7.0
       publint: 0.3.21
-      typescript: 5.9.3
-      yaml: 2.9.0
-
-  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)':
-    dependencies:
-      '@oxc-project/runtime': 0.133.0
-      '@oxc-project/types': 0.133.0
-      lightningcss: 1.32.0
-      postcss: 8.5.15
-    optionalDependencies:
-      '@types/node': 24.12.4
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
       typescript: 5.9.3
       yaml: 2.9.0
 
@@ -3295,46 +3331,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.4
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@vitejs/devtools'
-      - bufferutil
-      - esbuild
-      - jiti
-      - less
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - unrun
-      - utf-8-validate
-      - yaml
-
-  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.3
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
-      es-module-lexer: 1.7.0
-      obug: 2.1.1
-      pixelmatch: 7.2.0
-      pngjs: 7.0.0
-      sirv: 3.0.2
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.2
-      tinyglobby: 0.2.16
-      vite: 8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0)
-      ws: 8.21.0
-    optionalDependencies:
-      '@types/node': 24.12.4
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -4014,31 +4010,6 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
       vite-plus: 0.1.24(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
-  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
-    dependencies:
-      tinypool: 2.1.0
-    optionalDependencies:
-      '@oxfmt/binding-android-arm-eabi': 0.52.0
-      '@oxfmt/binding-android-arm64': 0.52.0
-      '@oxfmt/binding-darwin-arm64': 0.52.0
-      '@oxfmt/binding-darwin-x64': 0.52.0
-      '@oxfmt/binding-freebsd-x64': 0.52.0
-      '@oxfmt/binding-linux-arm-gnueabihf': 0.52.0
-      '@oxfmt/binding-linux-arm-musleabihf': 0.52.0
-      '@oxfmt/binding-linux-arm64-gnu': 0.52.0
-      '@oxfmt/binding-linux-arm64-musl': 0.52.0
-      '@oxfmt/binding-linux-ppc64-gnu': 0.52.0
-      '@oxfmt/binding-linux-riscv64-gnu': 0.52.0
-      '@oxfmt/binding-linux-riscv64-musl': 0.52.0
-      '@oxfmt/binding-linux-s390x-gnu': 0.52.0
-      '@oxfmt/binding-linux-x64-gnu': 0.52.0
-      '@oxfmt/binding-linux-x64-musl': 0.52.0
-      '@oxfmt/binding-openharmony-arm64': 0.52.0
-      '@oxfmt/binding-win32-arm64-msvc': 0.52.0
-      '@oxfmt/binding-win32-ia32-msvc': 0.52.0
-      '@oxfmt/binding-win32-x64-msvc': 0.52.0
-      vite-plus: 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
-
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
       '@oxlint-tsgolint/darwin-arm64': 0.23.0
@@ -4143,30 +4114,6 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
-
-  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
-    optionalDependencies:
-      '@oxlint/binding-android-arm-eabi': 1.67.0
-      '@oxlint/binding-android-arm64': 1.67.0
-      '@oxlint/binding-darwin-arm64': 1.67.0
-      '@oxlint/binding-darwin-x64': 1.67.0
-      '@oxlint/binding-freebsd-x64': 1.67.0
-      '@oxlint/binding-linux-arm-gnueabihf': 1.67.0
-      '@oxlint/binding-linux-arm-musleabihf': 1.67.0
-      '@oxlint/binding-linux-arm64-gnu': 1.67.0
-      '@oxlint/binding-linux-arm64-musl': 1.67.0
-      '@oxlint/binding-linux-ppc64-gnu': 1.67.0
-      '@oxlint/binding-linux-riscv64-gnu': 1.67.0
-      '@oxlint/binding-linux-riscv64-musl': 1.67.0
-      '@oxlint/binding-linux-s390x-gnu': 1.67.0
-      '@oxlint/binding-linux-x64-gnu': 1.67.0
-      '@oxlint/binding-linux-x64-musl': 1.67.0
-      '@oxlint/binding-openharmony-arm64': 1.67.0
-      '@oxlint/binding-win32-arm64-msvc': 1.67.0
-      '@oxlint/binding-win32-ia32-msvc': 1.67.0
-      '@oxlint/binding-win32-x64-msvc': 1.67.0
-      oxlint-tsgolint: 0.23.0
-      vite-plus: 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
   p-limit@7.3.0:
     dependencies:
@@ -4578,56 +4525,6 @@ snapshots:
       - vite
       - yaml
 
-  vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0):
-    dependencies:
-      '@oxc-project/types': 0.133.0
-      '@oxlint/plugins': 1.61.0
-      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
-      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
-      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
-      oxlint-tsgolint: 0.23.0
-    optionalDependencies:
-      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.24
-      '@voidzero-dev/vite-plus-darwin-x64': 0.1.24
-      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.24
-      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.24
-      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.24
-      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.24
-      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.24
-      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.24
-    transitivePeerDependencies:
-      - '@arethetypeswrong/core'
-      - '@edge-runtime/vm'
-      - '@opentelemetry/api'
-      - '@tsdown/css'
-      - '@tsdown/exe'
-      - '@types/node'
-      - '@vitejs/devtools'
-      - '@vitest/coverage-istanbul'
-      - '@vitest/coverage-v8'
-      - '@vitest/ui'
-      - bufferutil
-      - esbuild
-      - happy-dom
-      - jiti
-      - jsdom
-      - less
-      - publint
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - svelte
-      - terser
-      - tsx
-      - typescript
-      - unplugin-unused
-      - unrun
-      - utf-8-validate
-      - vite
-      - yaml
-
   vite@8.0.14(@types/node@24.12.4)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -4638,20 +4535,6 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.4
       '@vitejs/devtools': 0.2.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@8.0.14)
-      esbuild: 0.28.0
-      fsevents: 2.3.3
-      jiti: 2.7.0
-      yaml: 2.9.0
-
-  vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.15
-      rolldown: 1.0.2
-      tinyglobby: 0.2.16
-    optionalDependencies:
-      '@types/node': 24.12.4
       esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,75 +6,24 @@ settings:
 
 catalogs:
   default:
-    '@fontsource-variable/geist':
-      specifier: ^5.2.9
-      version: 5.2.9
-    '@fontsource-variable/jetbrains-mono':
-      specifier: ^5.2.8
-      version: 5.2.8
     '@types/node':
       specifier: ^24
       version: 24.12.4
-    '@vitejs/devtools':
-      specifier: 0.2.0
-      version: 0.2.0
-    '@vitejs/devtools-kit':
-      specifier: ^0.2.0
-      version: 0.2.0
-    '@vitejs/plugin-vue':
-      specifier: ^6.0.7
-      version: 6.0.7
-    '@vitest/coverage-v8':
-      specifier: ^4.1.7
-      version: 4.1.7
     '@volar/language-core':
       specifier: 2.4.15
       version: 2.4.15
     '@volar/typescript':
       specifier: 2.4.15
       version: 2.4.15
-    '@vue-flow/background':
-      specifier: ^1.3.2
-      version: 1.3.2
-    '@vue-flow/controls':
-      specifier: ^1.1.3
-      version: 1.1.3
-    '@vue-flow/core':
-      specifier: ^1.48.2
-      version: 1.48.2
-    binaryen:
-      specifier: ^129.0.0
-      version: 129.0.0
     esbuild:
       specifier: ^0.28.0
       version: 0.28.0
-    jszip:
-      specifier: ^3.10.1
-      version: 3.10.1
-    monaco-editor:
-      specifier: ^0.55.1
-      version: 0.55.1
-    muggle-string:
-      specifier: 0.4.1
-      version: 0.4.1
-    playwright:
-      specifier: ^1.60.0
-      version: 1.60.0
     typescript:
       specifier: ^5
       version: 5.9.3
     vite-plus:
       specifier: latest
       version: 0.1.24
-    vue:
-      specifier: ^3.5.34
-      version: 3.5.34
-    vue-router:
-      specifier: ^4.6.4
-      version: 4.6.4
-    wavefile:
-      specifier: ^11.0.0
-      version: 11.0.0
 
 overrides:
   vite: npm:@voidzero-dev/vite-plus-core@latest
@@ -190,9 +139,6 @@ importers:
       '@volar/typescript':
         specifier: 'catalog:'
         version: 2.4.15
-      muggle-string:
-        specifier: 'catalog:'
-        version: 0.4.1
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -214,7 +160,7 @@ importers:
         version: 0.28.0
       vite-plus:
         specifier: 'catalog:'
-        version: 0.1.24(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+        version: 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
   packages/offline:
     dependencies:
@@ -3216,6 +3162,20 @@ snapshots:
       typescript: 5.9.3
       yaml: 2.9.0
 
+  '@voidzero-dev/vite-plus-core@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)':
+    dependencies:
+      '@oxc-project/runtime': 0.133.0
+      '@oxc-project/types': 0.133.0
+      lightningcss: 1.32.0
+      postcss: 8.5.15
+    optionalDependencies:
+      '@types/node': 24.12.4
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      typescript: 5.9.3
+      yaml: 2.9.0
+
   '@voidzero-dev/vite-plus-darwin-arm64@0.1.24':
     optional: true
 
@@ -3335,6 +3295,46 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.4
       '@vitest/coverage-v8': 4.1.7(vitest@4.1.7)
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@vitejs/devtools'
+      - bufferutil
+      - esbuild
+      - jiti
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - yaml
+
+  '@voidzero-dev/vite-plus-test@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
+      es-module-lexer: 1.7.0
+      obug: 2.1.1
+      pixelmatch: 7.2.0
+      pngjs: 7.0.0
+      sirv: 3.0.2
+      std-env: 4.1.0
+      tinybench: 2.9.0
+      tinyexec: 1.2.2
+      tinyglobby: 0.2.16
+      vite: 8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0)
+      ws: 8.21.0
+    optionalDependencies:
+      '@types/node': 24.12.4
     transitivePeerDependencies:
       - '@arethetypeswrong/core'
       - '@tsdown/css'
@@ -4014,6 +4014,31 @@ snapshots:
       '@oxfmt/binding-win32-x64-msvc': 0.52.0
       vite-plus: 0.1.24(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
+  oxfmt@0.52.0(vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
+    dependencies:
+      tinypool: 2.1.0
+    optionalDependencies:
+      '@oxfmt/binding-android-arm-eabi': 0.52.0
+      '@oxfmt/binding-android-arm64': 0.52.0
+      '@oxfmt/binding-darwin-arm64': 0.52.0
+      '@oxfmt/binding-darwin-x64': 0.52.0
+      '@oxfmt/binding-freebsd-x64': 0.52.0
+      '@oxfmt/binding-linux-arm-gnueabihf': 0.52.0
+      '@oxfmt/binding-linux-arm-musleabihf': 0.52.0
+      '@oxfmt/binding-linux-arm64-gnu': 0.52.0
+      '@oxfmt/binding-linux-arm64-musl': 0.52.0
+      '@oxfmt/binding-linux-ppc64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-gnu': 0.52.0
+      '@oxfmt/binding-linux-riscv64-musl': 0.52.0
+      '@oxfmt/binding-linux-s390x-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-gnu': 0.52.0
+      '@oxfmt/binding-linux-x64-musl': 0.52.0
+      '@oxfmt/binding-openharmony-arm64': 0.52.0
+      '@oxfmt/binding-win32-arm64-msvc': 0.52.0
+      '@oxfmt/binding-win32-ia32-msvc': 0.52.0
+      '@oxfmt/binding-win32-x64-msvc': 0.52.0
+      vite-plus: 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+
   oxlint-tsgolint@0.23.0:
     optionalDependencies:
       '@oxlint-tsgolint/darwin-arm64': 0.23.0
@@ -4118,6 +4143,30 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.67.0
       oxlint-tsgolint: 0.23.0
       vite-plus: 0.1.24(@types/node@24.12.4)(@vitest/coverage-v8@4.1.7)(esbuild@0.28.0)(jiti@2.7.0)(publint@0.3.21)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+
+  oxlint@1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)):
+    optionalDependencies:
+      '@oxlint/binding-android-arm-eabi': 1.67.0
+      '@oxlint/binding-android-arm64': 1.67.0
+      '@oxlint/binding-darwin-arm64': 1.67.0
+      '@oxlint/binding-darwin-x64': 1.67.0
+      '@oxlint/binding-freebsd-x64': 1.67.0
+      '@oxlint/binding-linux-arm-gnueabihf': 1.67.0
+      '@oxlint/binding-linux-arm-musleabihf': 1.67.0
+      '@oxlint/binding-linux-arm64-gnu': 1.67.0
+      '@oxlint/binding-linux-arm64-musl': 1.67.0
+      '@oxlint/binding-linux-ppc64-gnu': 1.67.0
+      '@oxlint/binding-linux-riscv64-gnu': 1.67.0
+      '@oxlint/binding-linux-riscv64-musl': 1.67.0
+      '@oxlint/binding-linux-s390x-gnu': 1.67.0
+      '@oxlint/binding-linux-x64-gnu': 1.67.0
+      '@oxlint/binding-linux-x64-musl': 1.67.0
+      '@oxlint/binding-openharmony-arm64': 1.67.0
+      '@oxlint/binding-win32-arm64-msvc': 1.67.0
+      '@oxlint/binding-win32-ia32-msvc': 1.67.0
+      '@oxlint/binding-win32-x64-msvc': 1.67.0
+      oxlint-tsgolint: 0.23.0
+      vite-plus: 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
 
   p-limit@7.3.0:
     dependencies:
@@ -4529,6 +4578,56 @@ snapshots:
       - vite
       - yaml
 
+  vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0):
+    dependencies:
+      '@oxc-project/types': 0.133.0
+      '@oxlint/plugins': 1.61.0
+      '@voidzero-dev/vite-plus-core': 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(yaml@2.9.0)
+      '@voidzero-dev/vite-plus-test': 0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0)
+      oxfmt: 0.52.0(vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint: 1.67.0(oxlint-tsgolint@0.23.0)(vite-plus@0.1.24(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(typescript@5.9.3)(vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0))(yaml@2.9.0))
+      oxlint-tsgolint: 0.23.0
+    optionalDependencies:
+      '@voidzero-dev/vite-plus-darwin-arm64': 0.1.24
+      '@voidzero-dev/vite-plus-darwin-x64': 0.1.24
+      '@voidzero-dev/vite-plus-linux-arm64-gnu': 0.1.24
+      '@voidzero-dev/vite-plus-linux-arm64-musl': 0.1.24
+      '@voidzero-dev/vite-plus-linux-x64-gnu': 0.1.24
+      '@voidzero-dev/vite-plus-linux-x64-musl': 0.1.24
+      '@voidzero-dev/vite-plus-win32-arm64-msvc': 0.1.24
+      '@voidzero-dev/vite-plus-win32-x64-msvc': 0.1.24
+    transitivePeerDependencies:
+      - '@arethetypeswrong/core'
+      - '@edge-runtime/vm'
+      - '@opentelemetry/api'
+      - '@tsdown/css'
+      - '@tsdown/exe'
+      - '@types/node'
+      - '@vitejs/devtools'
+      - '@vitest/coverage-istanbul'
+      - '@vitest/coverage-v8'
+      - '@vitest/ui'
+      - bufferutil
+      - esbuild
+      - happy-dom
+      - jiti
+      - jsdom
+      - less
+      - publint
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - svelte
+      - terser
+      - tsx
+      - typescript
+      - unplugin-unused
+      - unrun
+      - utf-8-validate
+      - vite
+      - yaml
+
   vite@8.0.14(@types/node@24.12.4)(@vitejs/devtools@0.2.0)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -4539,6 +4638,20 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.12.4
       '@vitejs/devtools': 0.2.0(@pnpm/logger@1001.0.1)(typescript@5.9.3)(vite@8.0.14)
+      esbuild: 0.28.0
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      yaml: 2.9.0
+
+  vite@8.0.14(@types/node@24.12.4)(esbuild@0.28.0)(jiti@2.7.0)(yaml@2.9.0):
+    dependencies:
+      lightningcss: 1.32.0
+      picomatch: 4.0.4
+      postcss: 8.5.15
+      rolldown: 1.0.2
+      tinyglobby: 0.2.16
+    optionalDependencies:
+      '@types/node': 24.12.4
       esbuild: 0.28.0
       fsevents: 2.3.3
       jiti: 2.7.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,6 +32,9 @@ catalog:
   "@fontsource-variable/geist": ^5.2.9
   "@fontsource-variable/jetbrains-mono": ^5.2.8
   "@vitejs/devtools": 0.2.0
+  '@volar/language-core': 2.4.15
+  '@volar/typescript': 2.4.15
+  muggle-string: 0.4.1
 overrides:
   vite: "catalog:"
   vitest: "catalog:"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,8 +32,8 @@ catalog:
   "@fontsource-variable/geist": ^5.2.9
   "@fontsource-variable/jetbrains-mono": ^5.2.8
   "@vitejs/devtools": 0.2.0
-  '@volar/language-core': 2.4.15
-  '@volar/typescript': 2.4.15
+  "@volar/language-core": 2.4.15
+  "@volar/typescript": 2.4.15
   muggle-string: 0.4.1
 overrides:
   vite: "catalog:"


### PR DESCRIPTION
## What

`.uwk.ts` sugar syntax now type-checks correctly in the editor. Previously these
files needed `// @ts-nocheck` because tsserver couldn't understand the sugar.

A [Volar](https://volarjs.dev/) language plugin maps each `.uwk.ts` to virtual
TypeScript (with source ↔ generated mappings) and is loaded into tsserver via a
TS-server plugin, so the editor reports real diagnostics, hover, and completions
against the lowered code.

## Commits

- `4d5e3f8` **feat(lang)**: Volar language plugin + virtual code
  (`src/ide/virtualCode.ts`, `languagePlugin.ts`, `typescript-plugin.ts`)
- `25b17e4` **chore(lang)**: drop unused `muggle-string`; cover the quoted
  event-name path
- `bd9763c` **docs(lang)**: IDE setup — include the ambient `.d.ts` by path
- `47704dc` **fix(lang)**: ship `typescript-plugin/index.js` (CJS) so the real
  tsserver loads the plugin; adds tsserver integration tests

## Testing

- Virtual-code mapping + language-plugin unit tests
- Real tsserver integration test (open `.uwk.ts` → semantic diagnostics / quickinfo)
- `vp check` clean

## Not included

This branch is scoped to the IDE feature only. The v1.0.0 publish-prep work
(Changesets, package metadata, dist-exports, the dts-merge fix) is intentionally
left out and will come as a separate PR.

https://claude.ai/code/session_01Ve2sASLij77u3m9F3xYjhW

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ve2sASLij77u3m9F3xYjhW)_